### PR TITLE
fix spelling error in update user decks input name

### DIFF
--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -85,7 +85,7 @@ const typeDefs = `
         newPassword: String!
     }
 
-    input UpdateUserDeckInput {
+    input UpdateUserDecksInput {
         decks: [ID]
     }
 


### PR DESCRIPTION
The previous code was missing a letter in the `UpdateUserDecksInput` input. This fixes the errors caused by the mistake.

```
Error: Unknown type "UpdateUserDecksInput". Did you mean "UpdateUserDeckInput", "UpdateUserProfileInput", or "UpdateUserPasswordInput"?
```

Correction is in the input in typedefs. correct spelling is `UpdateUserDecksInput`