### PR TITLE
Add Query to Retrieve All Cards by Deck

### DIFF
--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -43,3 +43,13 @@ export const QUERY_ONE_DECK = gql`
     }
   }
 `;
+
+  export const QUERY_CARDS_BY_DECK = gql`
+    query allCardsByDeck($deckId: ID!) {
+    allCardsByDeck(deckId: $deckId)} {
+      _id
+        cards {
+        _id
+        }
+}
+`;

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -47,7 +47,6 @@ export const QUERY_ONE_DECK = gql`
   export const QUERY_CARDS_BY_DECK = gql`
     query allCardsByDeck($deckId: ID!) {
     allCardsByDeck(deckId: $deckId)} {
-      _id
         cards {
         _id
         }

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -67,8 +67,10 @@ const resolvers = {
             return Deck.findOne({ _id: deckId }).populate('cards');
         },
         allCardsByDeck: async (_, { deckId }) => {
-            return Deck.findOne({ _id: deckId }).select('cards -_id').populate('cards', '_id');
+            const deck = await Deck.findOne({ _id: deckId }).populate('cards');
+            return deck.cards.map(card => card._id);
         },
+            
         users: async () => {
             return User.find();
         },

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -66,7 +66,9 @@ const resolvers = {
         oneDeck: async (_, { deckId }) => {
             return Deck.findOne({ _id: deckId }).populate('cards');
         },
-
+        allCardsByDeck: async (_, { deckId }) => {
+            return Deck.findOne({ _id: deckId }).select('cards -_id').populate('cards', '_id');
+        },
         users: async () => {
             return User.find();
         },

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -102,6 +102,7 @@ const typeDefs = `
     type Query {
         allDecks: [Deck]
         oneDeck(deckId: ID!): Deck
+        allCardsByDeck(deckId: ID!): [Card]
         user(userId: ID!): User
         users: [User]
         me: User


### PR DESCRIPTION
**Description:**
This pull request introduces a new query, `allCardsByDeck`, which allows us to retrieve all card IDs associated with a specific deck. This addition is part of our ongoing efforts to enhance the functionality of our tarot reading app.

**Changes:**

**TypeDefs**: Added the `allCardsByDeck` query definition to our GraphQL type definitions. The query takes a `deckId` as an argument and returns an array of Card objects.

**Resolvers**: Implemented the resolver for the `allCardsByDeck` query. The resolver fetches the specified deck from the database and populates the cards field with the associated card documents. It then maps over the cards to return only their IDs.

**Queries.js**: Added the `ALL_CARDS_BY_DECK` query to our client-side query definitions. This query can be used in the Apollo sandbox or in our front-end components to fetch the card IDs for a given deck.

**Testing**:

**Compass**: Manually added a card to a deck in the MongoDB Compass to ensure that the database associations are correctly set up.
**Apollo Sandbox**: Tested the `allCardsByDeck` query in the Apollo sandbox with a valid `deckId` to confirm that it returns the expected array of card IDs.
**Note**: This implementation assumes that the associations between cards and decks are already established in the database. Future work may involve creating or updating these associations as needed.