### PR TITLE
Add Query to Retrieve a Single Card by ID

### DIFF
--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -52,3 +52,22 @@ export const QUERY_ONE_DECK = gql`
         }
 }
 `;
+
+  export const QUERY_ONE_CARD = gql`
+  query OneCard($cardId: ID!) {
+    oneCard(cardId: $cardId) {
+      _id
+      arcana
+      cardDescription
+      cardName
+      cardReverseImage
+      cardReverseMeaning
+      cardUprightImage
+      cardUprightMeaning
+      number
+      prominentColors
+      prominentSymbols
+      suit
+    }
+  }
+  `; 

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -43,3 +43,13 @@ export const QUERY_ONE_DECK = gql`
     }
   }
 `;
+
+  export const QUERY_CARDS_BY_DECK = gql`
+    query allCardsByDeck($deckId: ID!) {
+    allCardsByDeck(deckId: $deckId)} {
+      _id
+        cards {
+        _id
+        }
+}
+`;

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -47,7 +47,6 @@ export const QUERY_ONE_DECK = gql`
   export const QUERY_CARDS_BY_DECK = gql`
     query allCardsByDeck($deckId: ID!) {
     allCardsByDeck(deckId: $deckId)} {
-      _id
         cards {
         _id
         }

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -70,7 +70,9 @@ const resolvers = {
             const deck = await Deck.findOne({ _id: deckId }).populate('cards');
             return deck.cards.map(card => card._id);
         },
-            
+        oneCard: async (_, { cardId }) => {
+            return Card.findOne({ _id: cardId })
+        },
         users: async () => {
             return User.find();
         },

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -67,8 +67,10 @@ const resolvers = {
             return Deck.findOne({ _id: deckId }).populate('cards');
         },
         allCardsByDeck: async (_, { deckId }) => {
-            return Deck.findOne({ _id: deckId }).select('cards -_id').populate('cards', '_id');
+            const deck = await Deck.findOne({ _id: deckId }).populate('cards');
+            return deck.cards.map(card => card._id);
         },
+            
         users: async () => {
             return User.find();
         },

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -1,7 +1,8 @@
 const { AuthenticationError } = require('apollo-server-errors');
 const { 
     Deck, 
-    User 
+    User,
+    Card
 } = require('../models');
 const dateScalar = require('./DateScalar');
 

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -66,7 +66,9 @@ const resolvers = {
         oneDeck: async (_, { deckId }) => {
             return Deck.findOne({ _id: deckId }).populate('cards');
         },
-
+        allCardsByDeck: async (_, { deckId }) => {
+            return Deck.findOne({ _id: deckId }).select('cards -_id').populate('cards', '_id');
+        },
         users: async () => {
             return User.find();
         },

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -102,6 +102,7 @@ const typeDefs = `
     type Query {
         allDecks: [Deck]
         oneDeck(deckId: ID!): Deck
+        allCardsByDeck(deckId: ID!): [Card]
         user(userId: ID!): User
         users: [User]
         me: User

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -103,6 +103,7 @@ const typeDefs = `
         allDecks: [Deck]
         oneDeck(deckId: ID!): Deck
         allCardsByDeck(deckId: ID!): [Card]
+        oneCard(cardId: ID!): Card
         user(userId: ID!): User
         users: [User]
         me: User


### PR DESCRIPTION
**Description**:
This pull request introduces a new query, `oneCard`, which allows us to retrieve a single card by its ID. This addition enhances the querying capabilities of our tarot reading app, enabling more specific and targeted data retrieval.

**Changes**:

**TypeDefs**: Added the `oneCard` query definition to our GraphQL type definitions. The query takes a `cardId` as an argument and returns a `Card` object.

**Resolvers**: Implemented the resolver for the `oneCard` query. The resolver fetches the specified card from the database using its ID and returns the card object.

**Queries.js**: Added the `ONE_CARD` query to our client-side query definitions. This query can be used in the Apollo sandbox or in our front-end components to fetch a specific card by its ID.

**Testing**:

**Database**: Ensured that the card IDs are correctly indexed and can be queried efficiently.
**Apollo Sandbox**: Tested the `oneCard` query in the Apollo sandbox with a valid `cardId` to confirm that it returns the correct `Card` object.
**Note**: This query is a fundamental building block for future features that may require fetching specific cards, such as displaying card details or integrating card-based functionalities in our app.