### PR TITLE
Add Query to Retrieve a Single Spread by ID

### DIFF
--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -71,3 +71,17 @@ export const QUERY_ONE_DECK = gql`
     }
   }
   `; 
+
+export const QUERY_ONE_SPREAD = gql`
+  query OneSpread($spreadId: ID!) {
+  oneSpread(spreadId: $spreadId) {
+    _id
+    numCards
+    positions
+    spreadDescription
+    spreadImage
+    spreadName
+    spreadTips
+    tags
+  }
+}`;

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -52,3 +52,22 @@ export const QUERY_ONE_DECK = gql`
         }
 }
 `;
+
+  export const QUERY_ONE_CARD = gql`
+  query OneCard($cardId: ID!) {
+    oneCard(cardId: $cardId) {
+      _id
+      arcana
+      cardDescription
+      cardName
+      cardReverseImage
+      cardReverseMeaning
+      cardUprightImage
+      cardUprightMeaning
+      number
+      prominentColors
+      prominentSymbols
+      suit
+    }
+  }
+  `; 

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -43,3 +43,13 @@ export const QUERY_ONE_DECK = gql`
     }
   }
 `;
+
+  export const QUERY_CARDS_BY_DECK = gql`
+    query allCardsByDeck($deckId: ID!) {
+    allCardsByDeck(deckId: $deckId)} {
+      _id
+        cards {
+        _id
+        }
+}
+`;

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -47,7 +47,6 @@ export const QUERY_ONE_DECK = gql`
   export const QUERY_CARDS_BY_DECK = gql`
     query allCardsByDeck($deckId: ID!) {
     allCardsByDeck(deckId: $deckId)} {
-      _id
         cards {
         _id
         }

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -70,7 +70,9 @@ const resolvers = {
             const deck = await Deck.findOne({ _id: deckId }).populate('cards');
             return deck.cards.map(card => card._id);
         },
-            
+        oneCard: async (_, { cardId }) => {
+            return Card.findOne({ _id: cardId })
+        },
         users: async () => {
             return User.find();
         },

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -67,8 +67,10 @@ const resolvers = {
             return Deck.findOne({ _id: deckId }).populate('cards');
         },
         allCardsByDeck: async (_, { deckId }) => {
-            return Deck.findOne({ _id: deckId }).select('cards -_id').populate('cards', '_id');
+            const deck = await Deck.findOne({ _id: deckId }).populate('cards');
+            return deck.cards.map(card => card._id);
         },
+            
         users: async () => {
             return User.find();
         },

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -1,7 +1,8 @@
 const { AuthenticationError } = require('apollo-server-errors');
 const { 
     Deck, 
-    User 
+    User,
+    Card
 } = require('../models');
 const dateScalar = require('./DateScalar');
 

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -2,7 +2,8 @@ const { AuthenticationError } = require('apollo-server-errors');
 const { 
     Deck, 
     User,
-    Card
+    Card,
+    Spread
 } = require('../models');
 const dateScalar = require('./DateScalar');
 
@@ -73,6 +74,9 @@ const resolvers = {
         },
         oneCard: async (_, { cardId }) => {
             return Card.findOne({ _id: cardId })
+        },
+        oneSpread: async (_, { spreadId }) => {
+            return Spread.findOne({ _id: spreadId })
         },
         users: async () => {
             return User.find();

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -66,7 +66,9 @@ const resolvers = {
         oneDeck: async (_, { deckId }) => {
             return Deck.findOne({ _id: deckId }).populate('cards');
         },
-
+        allCardsByDeck: async (_, { deckId }) => {
+            return Deck.findOne({ _id: deckId }).select('cards -_id').populate('cards', '_id');
+        },
         users: async () => {
             return User.find();
         },

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -102,6 +102,7 @@ const typeDefs = `
     type Query {
         allDecks: [Deck]
         oneDeck(deckId: ID!): Deck
+        allCardsByDeck(deckId: ID!): [Card]
         user(userId: ID!): User
         users: [User]
         me: User

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -103,6 +103,7 @@ const typeDefs = `
         allDecks: [Deck]
         oneDeck(deckId: ID!): Deck
         allCardsByDeck(deckId: ID!): [Card]
+        oneCard(cardId: ID!): Card
         user(userId: ID!): User
         users: [User]
         me: User

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -104,6 +104,7 @@ const typeDefs = `
         oneDeck(deckId: ID!): Deck
         allCardsByDeck(deckId: ID!): [Card]
         oneCard(cardId: ID!): Card
+        oneSpread(spreadId: ID!): Spread
         user(userId: ID!): User
         users: [User]
         me: User


### PR DESCRIPTION
**Description**:
This pull request introduces a new query, `oneSpread`, which allows us to retrieve a single spread by its ID. This addition is part of our efforts to enhance the functionality of our tarot reading app, enabling users to access specific spread details.

**Changes**:

**TypeDefs**: Added the `oneSpread` query definition to our GraphQL type definitions. The query takes a `spreadId` as an argument and returns a `Spread` object.

**Resolvers**: Implemented the resolver for the `oneSpread` query. The resolver fetches the specified spread from the database using its ID and returns the `Spread` object.

**Queries.js**: Added the `ONE_SPREAD` query to our client-side query definitions. This query can be used in the Apollo sandbox or in our front-end components to fetch a specific spread by its ID.

**Testing**:

**Manual Spread Addition**: Manually added a spread to the database to ensure that the spread data can be correctly stored and retrieved.
**Apollo Sandbox**: Tested the `oneSpread` query in the Apollo sandbox with a valid spreadId to confirm that it returns the correct `Spread` object.
**Note**: This query is crucial for future features that may require fetching specific spreads, such as displaying spread details or integrating spread-based functionalities in our app.