### PR TITLE
Add Query to Retrieve All Spreads

### DIFF
--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -72,6 +72,16 @@ export const QUERY_ONE_DECK = gql`
   }
   `; 
 
+export const QUERY_ALL_SPREADS = gql`
+query AllSpreads {
+  allSpreads {
+    _id
+    spreadDescription
+    spreadImage
+    spreadName
+  }
+}`;
+
 export const QUERY_ONE_SPREAD = gql`
   query OneSpread($spreadId: ID!) {
   oneSpread(spreadId: $spreadId) {

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -71,3 +71,17 @@ export const QUERY_ONE_DECK = gql`
     }
   }
   `; 
+
+export const QUERY_ONE_SPREAD = gql`
+  query OneSpread($spreadId: ID!) {
+  oneSpread(spreadId: $spreadId) {
+    _id
+    numCards
+    positions
+    spreadDescription
+    spreadImage
+    spreadName
+    spreadTips
+    tags
+  }
+}`;

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -52,3 +52,22 @@ export const QUERY_ONE_DECK = gql`
         }
 }
 `;
+
+  export const QUERY_ONE_CARD = gql`
+  query OneCard($cardId: ID!) {
+    oneCard(cardId: $cardId) {
+      _id
+      arcana
+      cardDescription
+      cardName
+      cardReverseImage
+      cardReverseMeaning
+      cardUprightImage
+      cardUprightMeaning
+      number
+      prominentColors
+      prominentSymbols
+      suit
+    }
+  }
+  `; 

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -43,3 +43,13 @@ export const QUERY_ONE_DECK = gql`
     }
   }
 `;
+
+  export const QUERY_CARDS_BY_DECK = gql`
+    query allCardsByDeck($deckId: ID!) {
+    allCardsByDeck(deckId: $deckId)} {
+      _id
+        cards {
+        _id
+        }
+}
+`;

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -47,7 +47,6 @@ export const QUERY_ONE_DECK = gql`
   export const QUERY_CARDS_BY_DECK = gql`
     query allCardsByDeck($deckId: ID!) {
     allCardsByDeck(deckId: $deckId)} {
-      _id
         cards {
         _id
         }

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -70,7 +70,9 @@ const resolvers = {
             const deck = await Deck.findOne({ _id: deckId }).populate('cards');
             return deck.cards.map(card => card._id);
         },
-            
+        oneCard: async (_, { cardId }) => {
+            return Card.findOne({ _id: cardId })
+        },
         users: async () => {
             return User.find();
         },

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -75,6 +75,7 @@ const resolvers = {
         oneCard: async (_, { cardId }) => {
             return Card.findOne({ _id: cardId })
         },
+        allSpreads: async () => Spread.find(),
         oneSpread: async (_, { spreadId }) => {
             return Spread.findOne({ _id: spreadId })
         },

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -67,8 +67,10 @@ const resolvers = {
             return Deck.findOne({ _id: deckId }).populate('cards');
         },
         allCardsByDeck: async (_, { deckId }) => {
-            return Deck.findOne({ _id: deckId }).select('cards -_id').populate('cards', '_id');
+            const deck = await Deck.findOne({ _id: deckId }).populate('cards');
+            return deck.cards.map(card => card._id);
         },
+            
         users: async () => {
             return User.find();
         },

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -1,7 +1,8 @@
 const { AuthenticationError } = require('apollo-server-errors');
 const { 
     Deck, 
-    User 
+    User,
+    Card
 } = require('../models');
 const dateScalar = require('./DateScalar');
 

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -2,7 +2,8 @@ const { AuthenticationError } = require('apollo-server-errors');
 const { 
     Deck, 
     User,
-    Card
+    Card,
+    Spread
 } = require('../models');
 const dateScalar = require('./DateScalar');
 
@@ -73,6 +74,9 @@ const resolvers = {
         },
         oneCard: async (_, { cardId }) => {
             return Card.findOne({ _id: cardId })
+        },
+        oneSpread: async (_, { spreadId }) => {
+            return Spread.findOne({ _id: spreadId })
         },
         users: async () => {
             return User.find();

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -66,7 +66,9 @@ const resolvers = {
         oneDeck: async (_, { deckId }) => {
             return Deck.findOne({ _id: deckId }).populate('cards');
         },
-
+        allCardsByDeck: async (_, { deckId }) => {
+            return Deck.findOne({ _id: deckId }).select('cards -_id').populate('cards', '_id');
+        },
         users: async () => {
             return User.find();
         },

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -102,6 +102,7 @@ const typeDefs = `
     type Query {
         allDecks: [Deck]
         oneDeck(deckId: ID!): Deck
+        allCardsByDeck(deckId: ID!): [Card]
         user(userId: ID!): User
         users: [User]
         me: User

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -103,6 +103,7 @@ const typeDefs = `
         allDecks: [Deck]
         oneDeck(deckId: ID!): Deck
         allCardsByDeck(deckId: ID!): [Card]
+        oneCard(cardId: ID!): Card
         user(userId: ID!): User
         users: [User]
         me: User

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -104,7 +104,7 @@ const typeDefs = `
         oneDeck(deckId: ID!): Deck
         allCardsByDeck(deckId: ID!): [Card]
         oneCard(cardId: ID!): Card
-        allSpreads(spreadId: ID!): [Spread]
+        allSpreads: [Spread]
         oneSpread(spreadId: ID!): Spread
         user(userId: ID!): User
         users: [User]

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -104,6 +104,7 @@ const typeDefs = `
         oneDeck(deckId: ID!): Deck
         allCardsByDeck(deckId: ID!): [Card]
         oneCard(cardId: ID!): Card
+        oneSpread(spreadId: ID!): Spread
         user(userId: ID!): User
         users: [User]
         me: User

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -104,6 +104,7 @@ const typeDefs = `
         oneDeck(deckId: ID!): Deck
         allCardsByDeck(deckId: ID!): [Card]
         oneCard(cardId: ID!): Card
+        allSpreads(spreadId: ID!): [Spread]
         oneSpread(spreadId: ID!): Spread
         user(userId: ID!): User
         users: [User]


### PR DESCRIPTION
**Description**:
This pull request introduces a new query, `allSpreads`, which allows us to retrieve all spreads in the database. This addition enhances the querying capabilities of our tarot reading app, enabling users to explore and choose from a variety of spreads.

**Changes**:

**TypeDefs**: Added the `allSpreads` query definition to our GraphQL type definitions. The query returns an array of `Spread` objects.

**Resolvers**: Implemented the resolver for the `allSpreads` query. The resolver fetches all spreads from the database and returns them as an array of spread objects.

**Queries.js**: Added the `ALL_SPREADS` query to our client-side query definitions. This query can be used in the Apollo sandbox or in our front-end components to fetch all available spreads.

**Testing**:

**Database**: Ensured that the spreads are correctly stored and can be queried efficiently.
**Apollo Sandbox**: Tested the `allSpreads` query in the Apollo sandbox to confirm that it returns an array of all spread objects in the database.
**Note**: This query is essential for providing users with a comprehensive view of available spreads, which is crucial for enabling informed spread selection in our app.