### PR TITLE
Enhance oneSpread Query with Position Details

### DIFF
--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -72,6 +72,16 @@ export const QUERY_ONE_DECK = gql`
   }
   `; 
 
+export const QUERY_ALL_SPREADS = gql`
+query AllSpreads {
+  allSpreads {
+    _id
+    spreadDescription
+    spreadImage
+    spreadName
+  }
+}`;
+
 export const QUERY_ONE_SPREAD = gql`
   query OneSpread($spreadId: ID!) {
   oneSpread(spreadId: $spreadId) {

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -71,3 +71,17 @@ export const QUERY_ONE_DECK = gql`
     }
   }
   `; 
+
+export const QUERY_ONE_SPREAD = gql`
+  query OneSpread($spreadId: ID!) {
+  oneSpread(spreadId: $spreadId) {
+    _id
+    numCards
+    positions
+    spreadDescription
+    spreadImage
+    spreadName
+    spreadTips
+    tags
+  }
+}`;

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -83,15 +83,22 @@ query AllSpreads {
 }`;
 
 export const QUERY_ONE_SPREAD = gql`
-  query OneSpread($spreadId: ID!) {
+query OneSpread($spreadId: ID!) {
   oneSpread(spreadId: $spreadId) {
     _id
     numCards
-    positions
     spreadDescription
     spreadImage
     spreadName
     spreadTips
     tags
+    positions {
+      positionDescription
+      positionNumber
+      positionCoordinates {
+        x
+        y
+      }
+    }
   }
 }`;

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -52,3 +52,22 @@ export const QUERY_ONE_DECK = gql`
         }
 }
 `;
+
+  export const QUERY_ONE_CARD = gql`
+  query OneCard($cardId: ID!) {
+    oneCard(cardId: $cardId) {
+      _id
+      arcana
+      cardDescription
+      cardName
+      cardReverseImage
+      cardReverseMeaning
+      cardUprightImage
+      cardUprightMeaning
+      number
+      prominentColors
+      prominentSymbols
+      suit
+    }
+  }
+  `; 

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -43,3 +43,13 @@ export const QUERY_ONE_DECK = gql`
     }
   }
 `;
+
+  export const QUERY_CARDS_BY_DECK = gql`
+    query allCardsByDeck($deckId: ID!) {
+    allCardsByDeck(deckId: $deckId)} {
+      _id
+        cards {
+        _id
+        }
+}
+`;

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -47,7 +47,6 @@ export const QUERY_ONE_DECK = gql`
   export const QUERY_CARDS_BY_DECK = gql`
     query allCardsByDeck($deckId: ID!) {
     allCardsByDeck(deckId: $deckId)} {
-      _id
         cards {
         _id
         }

--- a/server/models/Spread.js
+++ b/server/models/Spread.js
@@ -3,6 +3,7 @@ const { Schema, model } = require('mongoose');
 const spreadSchema = new Schema({
   spreadName: {
     type: String,
+    required: true
   },
   spreadDescription: {
     type: String
@@ -12,8 +13,22 @@ const spreadSchema = new Schema({
   },
   numCards: {
     type: Number,
+    required: true
   },
-  positions: [String],
+  positions: [{
+    positionNumber: {
+      type: Number,
+      required: true
+    },
+    positionDescription: {
+      type: String,
+      required: true
+    },
+    positionCoordinates: {
+      x: Number,
+      y: Number
+    }
+  }],
   spreadTips: [String],
   tags: [String],
 });

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -70,7 +70,9 @@ const resolvers = {
             const deck = await Deck.findOne({ _id: deckId }).populate('cards');
             return deck.cards.map(card => card._id);
         },
-            
+        oneCard: async (_, { cardId }) => {
+            return Card.findOne({ _id: cardId })
+        },
         users: async () => {
             return User.find();
         },

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -75,6 +75,7 @@ const resolvers = {
         oneCard: async (_, { cardId }) => {
             return Card.findOne({ _id: cardId })
         },
+        allSpreads: async () => Spread.find(),
         oneSpread: async (_, { spreadId }) => {
             return Spread.findOne({ _id: spreadId })
         },

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -67,8 +67,10 @@ const resolvers = {
             return Deck.findOne({ _id: deckId }).populate('cards');
         },
         allCardsByDeck: async (_, { deckId }) => {
-            return Deck.findOne({ _id: deckId }).select('cards -_id').populate('cards', '_id');
+            const deck = await Deck.findOne({ _id: deckId }).populate('cards');
+            return deck.cards.map(card => card._id);
         },
+            
         users: async () => {
             return User.find();
         },

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -1,7 +1,8 @@
 const { AuthenticationError } = require('apollo-server-errors');
 const { 
     Deck, 
-    User 
+    User,
+    Card
 } = require('../models');
 const dateScalar = require('./DateScalar');
 

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -2,7 +2,8 @@ const { AuthenticationError } = require('apollo-server-errors');
 const { 
     Deck, 
     User,
-    Card
+    Card,
+    Spread
 } = require('../models');
 const dateScalar = require('./DateScalar');
 
@@ -73,6 +74,9 @@ const resolvers = {
         },
         oneCard: async (_, { cardId }) => {
             return Card.findOne({ _id: cardId })
+        },
+        oneSpread: async (_, { spreadId }) => {
+            return Spread.findOne({ _id: spreadId })
         },
         users: async () => {
             return User.find();

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -66,7 +66,9 @@ const resolvers = {
         oneDeck: async (_, { deckId }) => {
             return Deck.findOne({ _id: deckId }).populate('cards');
         },
-
+        allCardsByDeck: async (_, { deckId }) => {
+            return Deck.findOne({ _id: deckId }).select('cards -_id').populate('cards', '_id');
+        },
         users: async () => {
             return User.find();
         },

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -102,6 +102,7 @@ const typeDefs = `
     type Query {
         allDecks: [Deck]
         oneDeck(deckId: ID!): Deck
+        allCardsByDeck(deckId: ID!): [Card]
         user(userId: ID!): User
         users: [User]
         me: User

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -103,6 +103,7 @@ const typeDefs = `
         allDecks: [Deck]
         oneDeck(deckId: ID!): Deck
         allCardsByDeck(deckId: ID!): [Card]
+        oneCard(cardId: ID!): Card
         user(userId: ID!): User
         users: [User]
         me: User

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -104,7 +104,7 @@ const typeDefs = `
         oneDeck(deckId: ID!): Deck
         allCardsByDeck(deckId: ID!): [Card]
         oneCard(cardId: ID!): Card
-        allSpreads(spreadId: ID!): [Spread]
+        allSpreads: [Spread]
         oneSpread(spreadId: ID!): Spread
         user(userId: ID!): User
         users: [User]

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -104,6 +104,7 @@ const typeDefs = `
         oneDeck(deckId: ID!): Deck
         allCardsByDeck(deckId: ID!): [Card]
         oneCard(cardId: ID!): Card
+        oneSpread(spreadId: ID!): Spread
         user(userId: ID!): User
         users: [User]
         me: User

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -104,6 +104,7 @@ const typeDefs = `
         oneDeck(deckId: ID!): Deck
         allCardsByDeck(deckId: ID!): [Card]
         oneCard(cardId: ID!): Card
+        allSpreads(spreadId: ID!): [Spread]
         oneSpread(spreadId: ID!): Spread
         user(userId: ID!): User
         users: [User]

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -47,9 +47,20 @@ const typeDefs = `
         spreadDescription: String
         spreadImage: String
         numCards: Int
-        positions:[String]
+        positions:[SpreadPositions]
         spreadTips: [String]
         tags: [String]
+    }
+
+    type SpreadPositions {
+        positionNumber: Int
+        positionDescription: String
+        positionCoordinates: PositionCoords
+    }
+
+    type PositionCoords {
+        x: Int
+        y: Int
     }
 
     type Reading {


### PR DESCRIPTION
**Description**:
This pull request updates the `oneSpread` query to include detailed information about each position within a spread. This enhancement allows us to retrieve not only the basic spread information but also the specific details of each position, including their descriptions and coordinates. This update is crucial for rendering spreads accurately in the frontend and providing users with a more comprehensive understanding of each spread.

**Changes**:

**MongoDB Model**: Updated the `Spread` model in MongoDB to include a subdocument for positions, each with a number, description, and coordinates.

**GraphQL TypeDefs**: Modified the `Spread` type in GraphQL to reflect the new structure of positions, including a separate `SpreadPositions` type and a `PositionCoords` type for coordinates.

**Frontend Query**: Updated the `QUERY_ONE_SPREAD` query in the frontend to fetch the additional position details, including the position number, description, and coordinates.

**Testing**:

**Database**: Verified that the updated `Spread` model correctly stores and retrieves spreads with detailed position information.
**GraphQL Playground**: Tested the updated `oneSpread` query in the GraphQL playground to ensure that it returns the expected data, including position details.
**Note**: This update enhances the functionality of our tarot reading app by providing users with more detailed information about each spread, contributing to a richer user experience.