### PR TITLE
Add Mutation to Create User-Specific Tarot Reading

### DIFF
--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -63,13 +63,19 @@ const checkAuthentication = (context, userId) => {
     }
 };
 
-function shuffleArray(array) {
+const shuffleArray = (array) => {
   for (let i = array.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
     [array[i], array[j]] = [array[j], array[i]];
   }
   return array;
 }
+
+const drawCards = (deck, numberOfCards) => {
+  const shuffledDeck = shuffleArray([...deck]);
+  return shuffledDeck.slice(0, numberOfCards);
+}
+
 
 const resolvers = {
 

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -63,6 +63,14 @@ const checkAuthentication = (context, userId) => {
     }
 };
 
+function shuffleArray(array) {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+  return array;
+}
+
 const resolvers = {
 
     Date: dateScalar,

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -57,6 +57,8 @@ const updateObjectArrays = async (
 };
 
 const checkAuthentication = (context, userId) => {
+    console.log('User in context:', context.user);
+    console.log('User ID to check:', userId);
     if (!context.user || context.user._id !== userId) {
         throw new AuthenticationError(
             'You need to be logged in to perform this action!'
@@ -186,8 +188,13 @@ const resolvers = {
             );
         },
 
-        createTarotReading: async (_, {userId, deckId, spreadId }, context) => {
+        createTarotReading: async (_, { userId, deckId, spreadId }, context) => {
+            // if (!context.user) {
+            //     throw new AuthenticationError('You need to be logged in to perform this action!');
+            // }
+
             checkAuthentication(context, userId);
+
             const spread = await Spread.findOne({ _id: spreadId });
             const deck = await Deck.findOne({ _id: deckId }).populate('cards');
             const selectedCards = drawCards(deck.cards, spread.numCards);

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -130,7 +130,7 @@ const typeDefs = `
     }
 
     type Mutation {
-        createTarotReading(deckId: ID!, spreadId: ID!): Reading!
+        createTarotReading(userId: ID!, deckId: ID!, spreadId: ID!): Reading
         signup(username: String!, email: String!, password: String!): Auth
         login(email: String!, password: String!): Auth
         updateUserProfile(userId: ID!, input: UpdateUserProfileInput):User

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -130,6 +130,7 @@ const typeDefs = `
     }
 
     type Mutation {
+        createTarotReading(deckId: ID!, spreadId: ID!): Reading!
         signup(username: String!, email: String!, password: String!): Auth
         login(email: String!, password: String!): Auth
         updateUserProfile(userId: ID!, input: UpdateUserProfileInput):User

--- a/server/utils/auth.js
+++ b/server/utils/auth.js
@@ -4,31 +4,33 @@ const secret = 'mysecretssshhhhhhh';
 const expiration = '2h';
 
 module.exports = {
-    authMiddleware: function ({ req }) {
-        // allows token to be sent via req.body, req.query, or headers
-        let token =
-            req.body.token || req.query.token || req.headers.authorization;
+authMiddleware: function ({ req }) {
+    // allows token to be sent via req.body, req.query, or headers
+    let token =
+        req.body.token || req.query.token || req.headers.authorization;
 
-        // We split the token string into an array and return actual token
-        if (req.headers.authorization) {
-            token = token.split(' ').pop().trim();
-        }
+    // We split the token string into an array and return actual token
+    if (req.headers.authorization) {
+        token = token.split(' ').pop().trim();
+    }
 
-        if (!token) {
-            return req;
-        }
+    // Initialize an empty user object
+    let user = null;
 
+    if (token) {
         // if token can be verified, add the decoded user's data to the request so it can be accessed in the resolver
         try {
             const { data } = jwt.verify(token, secret, { maxAge: expiration });
-            req.user = data;
+            user = data;
         } catch {
             console.log('Invalid token');
         }
+    }
 
-        // return the request object so it can be passed to the resolver as `context`
-        return req;
-    },
+    // return an object with the user property so it can be passed to the resolver as `context`
+    return { user };
+},
+
     signToken: function ({ email, username, _id }) {
         const payload = { email, username, _id };
         return jwt.sign({ data: payload }, secret, { expiresIn: expiration });


### PR DESCRIPTION
**Description**:
This PR introduces a new GraphQL mutation to create a user-specific tarot reading based on a selected deck and spread. The mutation allows users to generate a reading that is saved for future reference.

**Changes Made**:

- Added a new mutation `createTarotReading` to the GraphQL schema
- Implemented the `createTarotReading` resolver function to handle the creation of a reading
- Updated the `checkAuthentication` function to ensure the user is logged in before creating a reading
- Updated the `Reading` model to include user-specific information such as user, deck, spread, and cards
- Added `shuffleArray` and `drawCards` functions to handle shuffling and drawing cards for the reading

**Purpose**:
This feature enhances the functionality of the tarot reading app by allowing users to generate and save personalized readings. It adds value to the user experience by providing a way to revisit and reflect on past readings.

**Testing**:

Tested the `createTarotReading` mutation using a sandbox environment, ensuring that readings are successfully created and saved for the user
Verified that the `createTarotReading` mutation works as expected with valid user authentication and input data
**Additional Notes**:

This PR lays the foundation for future enhancements, such as displaying saved readings in the user's profile or allowing users to revisit past readings in the app.