### PR TITLE
Add allReadingsByUser query and resolver.

### DIFF
--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -103,67 +103,25 @@ const resolvers = {
             return Spread.findOne({ _id: spreadId })
       },
         
-// allReadingsByUser: async (_, { userId }, context) => {
-//   checkAuthentication(context, userId);
-//     console.log("userId:", userId);
-  
-//     const user = await User.findById(userId).populate('readings');
-//     const readingIds = user.readings.map(reading => reading._id);
+        allReadingsByUser: async (_, { userId }, context) => {
+            checkAuthentication(context, userId);
 
-// const readings = await Reading.find({ _id: { $in: readingIds } })
-//     .populate('deck', 'deckName')
-//     .populate('spread', 'spreadName');
-//     console.log("readings:", readings);
+            const user = await User.findById(userId).populate('readings');
+            const readingIds = user.readings.map(reading => reading._id);
 
-//     const formattedReadings = readings.map(reading => ({
-//         date: reading.dateCreated,
-//         deck: reading.deck ? reading.deck.deckName : null,
-//         spread: reading.spread ? reading.spread.spreadName : null,
-//         userNotes: reading.userNotes,
-//         _id: reading._id
-//     }));
-//   console.log("\n\n\n")
-// console.log(formattedReadings)
-//     return formattedReadings;
-// },
-  allReadingsByUser: async (_, { userId }, context) => {
-    checkAuthentication(context, userId);
+            const readings = await Reading.find({ _id: { $in: readingIds } })
+                .populate({
+                    path: 'deck',
+                    select: 'deckName'
+                })
+                .populate({
+                    path: 'spread',
+                    select: 'spreadName'
+                });
 
-    const user = await User.findById(userId).populate('readings');
-    const readingIds = user.readings.map(reading => reading._id);
+            return readings;
+        },
 
-    const readings = await Reading.find({ _id: { $in: readingIds } })
-        .populate({
-            path: 'deck',
-            select: 'deckName'
-        })
-        .populate({
-            path: 'spread',
-            select: 'spreadName'
-        });
-
-    return readings;
-},
-
-
-        // allReadingsByUser: async( _, { userId }, context) => {
-        //     checkAuthentication(context, userId);
-        //     return Reading.find({ user: userId }).populate('deck spread user');
-
-        //   // const formattedReadings = readings.map(reading => {
-        //   //     console.log('Reading ID:', reading._id);
-        //   //   return {
-        //   //       user: reading.user._id,
-        //   //         date: reading.dateCreated,
-        //   //         deckName: reading.deck ? reading.deck.deckName : null,
-        //   //         spreadName: reading.spread ? reading.spread.spreadName : null,
-        //   //         notes: reading.userNotes,
-        //   //         _id: reading._id // Ensure _id is not null
-        //   //     };
-        //   // });
-
-        //   // return formattedReadings;
-        // },
         users: async () => {
             return User.find();
         },

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -102,23 +102,49 @@ const resolvers = {
         oneSpread: async (_, { spreadId }) => {
             return Spread.findOne({ _id: spreadId })
       },
-        allReadingsByUser: async (_, { userId }, context) => {
+        
+// allReadingsByUser: async (_, { userId }, context) => {
+//   checkAuthentication(context, userId);
+//     console.log("userId:", userId);
+  
+//     const user = await User.findById(userId).populate('readings');
+//     const readingIds = user.readings.map(reading => reading._id);
+
+// const readings = await Reading.find({ _id: { $in: readingIds } })
+//     .populate('deck', 'deckName')
+//     .populate('spread', 'spreadName');
+//     console.log("readings:", readings);
+
+//     const formattedReadings = readings.map(reading => ({
+//         date: reading.dateCreated,
+//         deck: reading.deck ? reading.deck.deckName : null,
+//         spread: reading.spread ? reading.spread.spreadName : null,
+//         userNotes: reading.userNotes,
+//         _id: reading._id
+//     }));
+//   console.log("\n\n\n")
+// console.log(formattedReadings)
+//     return formattedReadings;
+// },
+  allReadingsByUser: async (_, { userId }, context) => {
     checkAuthentication(context, userId);
+
     const user = await User.findById(userId).populate('readings');
     const readingIds = user.readings.map(reading => reading._id);
 
-    const readings = await Reading.find({ _id: { $in: readingIds } }).populate('deck spread').lean();
+    const readings = await Reading.find({ _id: { $in: readingIds } })
+        .populate({
+            path: 'deck',
+            select: 'deckName'
+        })
+        .populate({
+            path: 'spread',
+            select: 'spreadName'
+        });
 
-    const formattedReadings = readings.map(reading => ({
-        date: reading.dateCreated,
-        deckName: reading.deck ? reading.deck.deckName : null,
-        spreadName: reading.spread ? reading.spread.spreadName : null,
-        notes: reading.userNotes,
-        _id: reading._id
-    }));
-
-    return formattedReadings;
+    return readings;
 },
+
 
         // allReadingsByUser: async( _, { userId }, context) => {
         //     checkAuthentication(context, userId);

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -104,7 +104,20 @@ const resolvers = {
       },
         allReadingsByUser: async( _, { userId }, context) => {
             checkAuthentication(context, userId);
-            return Reading.find({_id: userId}).populate('cards')
+            const readings = await Reading.find({ user: userId }).populate('deck spread').lean();
+
+          const formattedReadings = readings.map(reading => {
+              console.log('Reading ID:', reading._id);
+              return {
+                  date: reading.createdAt,
+                  deckName: reading.deck ? reading.deck.deckName : null,
+                  spreadName: reading.spread ? reading.spread.spreadName : null,
+                  notes: reading.userNotes,
+                  _id: reading._id // Ensure _id is not null
+              };
+          });
+
+          return formattedReadings;
         },
         users: async () => {
             return User.find();

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -120,6 +120,7 @@ const typeDefs = `
         oneCard(cardId: ID!): Card
         allSpreads: [Spread]
         oneSpread(spreadId: ID!): Spread
+        allReadingsByUser(userId: ID!): [Reading]
         user(userId: ID!): User
         users: [User]
         me: User

--- a/server/seeders/seed.js
+++ b/server/seeders/seed.js
@@ -1,9 +1,10 @@
 require('dotenv').config(); 
 const db = require('../config/connection');
-const { Card, Deck, Spread } = require('../models');
+const { Card, Deck, Spread, Reading } = require('../models');
 const cardSeeds = require('./cardSeeds.json');
 const deckSeeds = require('./deckSeeds.json');
 const spreadSeeds = require('./spreadSeeds.json');
+
 const cleanDB = require('./cleanDB');
 
 db.once('open', async () => {


### PR DESCRIPTION
**Description**: This PR adds the `allReadingsByUser` query to the type definitions and implements the logic to assign readings to the user object on creation. Additionally, it adds a resolver to find the user and their associated readings, populating the deck name and spread name for the dashboard. The PR also includes fixes for null errors related to deck/spread information population.

**Changes Made:**

- Added `allReadingsByUser` query to type definitions.
- Implemented logic to assign readings to the user object on creation.
- Added resolver to find the user and their associated readings, populating deck name and spread name for the dashboard.
- Resolved null errors related to deck/spread information population.
-
**Testing**:

-  Tested the functionality by creating several new readings and finding them with the user id. Verified that the dashboard displays the populated deck and spread names correctly.

**Additional Notes:** 

- Future improvements may include optimizing the resolver for better performance with a large number of readings.