### PR TITLE
fixed update reading notes mutation and typedef information

### DIFF
--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -243,7 +243,9 @@ const resolvers = {
       reading.userNotes = input;
       await reading.save();
 
-      return reading;
+      return {
+        message: 'Notes added successfully to reading.'
+      };
     },
 
     // Mutation to delete their account when logged in

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -113,6 +113,10 @@ const typeDefs = `
         textBody: String
     }
 
+    type UpdateReadingNotesMessage {
+        message: String!
+    }
+
     type Auth {
         token: ID!
         user: User
@@ -137,14 +141,14 @@ const typeDefs = `
     }
 
     type Mutation {
-        createTarotReading(userId: ID!, deckId: ID!, spreadId: ID!): UserNotes
+        createTarotReading(userId: ID!, deckId: ID!, spreadId: ID!): Reading
         signup(username: String!, email: String!, password: String!): Auth
         login(email: String!, password: String!): Auth
         updateUserProfile(userId: ID!, input: UpdateUserProfileInput):User
         updateUserPassword(userId: ID!, input: UpdateUserPasswordInput): User
         updateUserDecks(userId: ID!, input: UpdateUserDecksInput): User
         updateUserReadings(userId: ID!, input: UpdateUserReadingsInput): User
-        updateReadingNotes(userId: ID!, readingId: ID!, input: UpdateReadingNotesInput): Reading
+        updateReadingNotes(userId: ID!, readingId: ID!, input: UpdateReadingNotesInput): UpdateReadingNotesMessage
 
         deleteUser(userId: ID!): DeleteUser
     }


### PR DESCRIPTION
**Description:**

This pull request introduces a fix to the issue in pr 89 that does not allow the user to update a reading with personal notes. 

**Changes:**

- Edited `createTarotReading` mutation in typedefs to return reading info
- Added `updateUserNotesMessage` type to contain a message on success
- Edited `updateReadingNotes` mutation in typedefs to return the update reading notes message
- edited return statement in mutations resolver to return a message "Notes added successfully to reading."