### PR TITLE
Queries/single reading

### DIFF
--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -111,3 +111,12 @@ export const QUERY_ONE_SPREAD = gql`
         }
     }
 `;
+
+
+export const QUERY_ONE_READING = gql`
+    query OneReading($userId: ID!, $readingId: ID!){
+        oneReadingByUser(userId: $userId, spreadId: $spreadId){
+        _id
+        
+        }}
+`

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -91,33 +91,46 @@ const resolvers = {
       return Spread.findOne({ _id: spreadId });
     },
 
-allReadingsByUser: async (_, { userId }, context) => {
-  checkAuthentication(context, userId);
+    allReadingsByUser: async (_, { userId }, context) => {
+      checkAuthentication(context, userId);
 
-  const user = await User.findById(userId).populate('readings');
-  const readingIds = user.readings.map((reading) => reading._id);
+      const user = await User.findById(userId).populate('readings');
+      const readingIds = user.readings.map((reading) => reading._id);
 
-  const readings = await Reading.find({ _id: { $in: readingIds } })
-    .populate({
-      path: 'deck',
-      select: 'deckName',
-    })
-    .populate({
-      path: 'spread',
-      select: 'spreadName',
-    })
-    .populate({
-      path: 'cards.card',
-      select: 'cardName',
-    })
-    .populate({
-        path: 'userNotes',
-        select: 'noteTitle'
-    });
+        const readings = await Reading.find({ _id: { $in: readingIds } })
+          .populate({
+            path: 'deck',
+            select: 'deckName',
+          })
+          .populate({
+            path: 'spread',
+            select: 'spreadName',
+          })
+          .populate({
+            path: 'cards.card',
+            select: 'cardName',
+          })
+          .populate({
+              path: 'userNotes',
+              select: 'noteTitle'
+          });
 
-  return readings;
-},
-
+        return readings;
+      },
+      oneReadingByUser: async (_, { userId, readingId }, context) => {
+        const reading = await Reading.findById(readingId);
+    
+        if (!reading) {
+            throw new Error('Reading not found');
+        }
+    
+        if (reading.user.toString() !== userId) {
+            throw new Error('Unauthorized access to reading');
+        }
+    
+        return reading;
+    },
+    
 
     users: async () => {
       return User.find();

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -118,8 +118,9 @@ const resolvers = {
         return readings;
       },
       oneReadingByUser: async (_, { userId, readingId }, context) => {
+        checkAuthentication(context, userId);
         const reading = await Reading.findById(readingId);
-    
+        console.log(reading)
         if (!reading) {
             throw new Error('Reading not found');
         }

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -130,6 +130,7 @@ const typeDefs = `
         allSpreads: [Spread]
         oneSpread(spreadId: ID!): Spread
         allReadingsByUser(userId: ID!): [Reading]
+        oneReadingByUser(userId: ID!, ReadingId: ID!)Reading
         user(userId: ID!): User
         users: [User]
         me: User

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -130,7 +130,7 @@ const typeDefs = `
         allSpreads: [Spread]
         oneSpread(spreadId: ID!): Spread
         allReadingsByUser(userId: ID!): [Reading]
-        oneReadingByUser(userId: ID!, ReadingId: ID!)Reading
+        oneReadingByUser(userId: ID!, readingId: ID!): Reading
         user(userId: ID!): User
         users: [User]
         me: User


### PR DESCRIPTION
**Description**: This PR adds the `oneReadingByUser` query to the type definitions and implements the logic to find a singular reading and ensure it can only be accessed by the correct user.

**Changes Made:**

- Added `oneReadingByUser` query to type definitions.
- Implemented logic to ensure only the owner of the reading can access it
- Added resolver to find the reading and check it against the userId
- Resolved errors related to "cannot find reading" error
-
**Testing**:

-  Tested the functionality by creating several new readings and finding them with the user id and reading id.

**Additional Notes:** 

- Future improvements may include optimizing the resolver for better performance with a large number of readings.