### PR TITLE
fix scrollbar issues on pages with nav panes

### DIFF
--- a/client/src/components/NavigationPane/NavigationPane.css
+++ b/client/src/components/NavigationPane/NavigationPane.css
@@ -4,7 +4,7 @@
     width: 150px;
     background-color: #4F3052;
     padding-left: 5px;
-    padding-top: 5px;
+    /* padding-top: 5px; */
     display: flex;
     flex-direction: column;
     justify-content: space-between;
@@ -32,7 +32,7 @@
     height: 100%;
     width: 50px;
     background-color: #4F3052;
-    padding-top: 5px;
+    /* padding-top: 5px; */
     display: flex;
     flex-direction: column;
     justify-content: space-between;


### PR DESCRIPTION
This PR fixes the horizontal and vertical scroll bars on any pages with the nav links and icons components.

##Changes
- removed `padding-top` from `navLinks` and `navIcons` components