### PR TITLE
Created AuthComponent for use on all 3 panels of the landing page

### DIFF
--- a/client/src/components/FooterPane/SimpleFooter.jsx
+++ b/client/src/components/FooterPane/SimpleFooter.jsx
@@ -2,22 +2,22 @@ import { Link } from 'react-router-dom';
 
 const SimpleFooter = () => {
     return (
-        <footer style={{ position: 'fixed', bottom: '0', width: '100%', backgroundColor: 'transparent', zIndex: '5' }}>
+        <footer style={{ position: 'fixed', bottom: '0', width: '100%', backgroundColor: 'black', zIndex: '5' }}>
             <div style={{ display: 'flex',  width: "35%", margin: 'auto' }}>
-            <ul style={ { display: 'flex', listStyleType: 'none', width: '100%', padding: '.5em', borderTop: '1px solid whitesmoke', margin: 'auto' } }>
-                    <li style={ { marginRight: '2rem' } }>
+            <ul style={ { display: 'flex', listStyleType: 'none', width: '100%', padding: '.8em', margin: 'auto', justifyContent: 'center'} }>
+                    <li style={ { margin: '0 1rem' } }>
                         <Link to="/aboutUs" style={ { textDecoration: 'none', color: '#cccccc' } }>Meet the Team</Link>
                     </li>
-                    <li style={ { marginRight: '2rem' } }>
+                    <li style={ { margin: '0 1rem'  } }>
                         <Link to="/contactUs" style={ { textDecoration: 'none', color: '#cccccc' } }>Contact Us</Link>
                     </li>
-                    <li style={ { marginRight: '2rem' } }>
+                    <li style={ { margin: '0 1rem'  } }>
                         <Link to="/faqs" style={ { textDecoration: 'none', color: '#cccccc' } }>FAQs</Link>
                     </li>
-                    <li style={ { marginRight: '2rem' } }>
+                    <li style={ { margin: '0 1rem'  } }>
                         <Link to="/terms" style={ { textDecoration: 'none', color: '#cccccc' } }>Terms</Link>
                     </li>
-                    <li style={ { marginRight: '2rem' } }>
+                    <li style={ { margin: '0 1rem'  } }>
                         <Link to="/privacy" style={ { textDecoration: 'none', color: '#cccccc' } }>Privacy</Link>
                     </li>
                 </ul>

--- a/client/src/pages/Landing/Landing.css
+++ b/client/src/pages/Landing/Landing.css
@@ -138,6 +138,10 @@
     margin: 25px;
     z-index: 5;
 }
+.icon.selected {
+    transform: scale(1.1);
+    transition: transform 0.2s ease;
+}
 .icon-font {
     display: flex;
     font-size: 34px;
@@ -160,10 +164,6 @@
     margin-top: 0;
     width: 65vw;
     line-height: 60px;
-    font-size: large;
+    font-size: x-large;
     text-shadow: 1px 1px 1px rgb(168, 148, 103);
-}
-.simple-footer-buttons {
-    margin: 0;
-    z-index: 5;
 }

--- a/client/src/pages/Landing/Login_Signup/AuthButtons.jsx
+++ b/client/src/pages/Landing/Login_Signup/AuthButtons.jsx
@@ -1,0 +1,16 @@
+import React, { useState } from 'react';
+
+export const AuthButtons = ({ handleLoginOpen, handleSignUpOpen }) => {
+    return (
+        <div className='button-container'>
+            <div>
+                <button className='button' onClick={handleLoginOpen}>
+                    Login
+                </button>
+                <button className='button' onClick={handleSignUpOpen}>
+                    Sign Up
+                </button>
+            </div>
+        </div>
+    );
+};

--- a/client/src/pages/Landing/Login_Signup/AuthComponent.jsx
+++ b/client/src/pages/Landing/Login_Signup/AuthComponent.jsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import { AuthButtons } from './AuthButtons';
+import LoginModal from './LoginModal';
+import SignupModal from './SignUpModal';
+
+const AuthComponent = () => {
+    const [loginOpen, setLoginOpen] = useState(false);
+    const [signupOpen, setSignupOpen] = useState(false);
+
+    const handleLoginOpen = () => setLoginOpen(true);
+    const handleLoginClose = () => setLoginOpen(false);
+
+    const handleSignUpOpen = () => setSignupOpen(true);
+    const handleSignUpClose = () => setSignupOpen(false);
+
+    return (
+        <>
+            <AuthButtons
+                handleLoginOpen={handleLoginOpen}
+                handleSignUpOpen={handleSignUpOpen}
+            />
+             <LoginModal open={loginOpen} handleClose={handleLoginClose} />
+            <SignupModal open={signupOpen} handleClose={handleSignUpClose} />
+        </>
+    );
+};
+
+export default AuthComponent;

--- a/client/src/pages/Landing/PanelOne.jsx
+++ b/client/src/pages/Landing/PanelOne.jsx
@@ -1,23 +1,12 @@
 import { Link } from 'react-router-dom';
-import { useState } from 'react';
 import Logo from '../../assets/tarot_logo.png';
 import MoonUp from '../../assets/Up_moon.png';
 import MoonDown from '../../assets/Down_moon.png';
 import BackgroundImage from '../../assets/TarotHeader1.png';
 import StarsBackground from '../Landing/Assets/Stars.png';
-import LoginModal from './Login_Signup/LoginModal';
-import SignupModal from './Login_Signup/SignUpModal';
+import AuthComponent from './Login_Signup/AuthComponent';
 
 const PanelOne = () => {
-    const [loginOpen, setLoginOpen] = useState(false);
-    const [signupOpen, setSignupOpen] = useState(false);
-
-    const handleLoginOpen = () => setLoginOpen(true);
-    const handleLoginClose = () => setLoginOpen(false);
-
-    const handleSignUpOpen = () => setSignupOpen(true);
-    const handleSignUpClose = () => setSignupOpen(false);
-
     return (
         <div
             className='panel-container'
@@ -44,18 +33,7 @@ const PanelOne = () => {
                 Embark on an Enlightening <br /> Journey with Tarot
             </h1>
             <img src={MoonDown} alt='Moon decorative element' />
-            <div className='button-container'>
-                <div>
-                    <button className='button' onClick={handleLoginOpen}>
-                        Login
-                    </button>
-                    <button className='button' onClick={handleSignUpOpen}>
-                        Sign Up
-                    </button>
-                </div>
-            </div>
-            <LoginModal open={loginOpen} handleClose={handleLoginClose} />
-            <SignupModal open={signupOpen} handleClose={handleSignUpClose} />
+            <AuthComponent />
         </div>
     );
 };

--- a/client/src/pages/Landing/PanelThree.jsx
+++ b/client/src/pages/Landing/PanelThree.jsx
@@ -10,6 +10,7 @@ import StoreDesc from './IconDescriptions/StoreDesc';
 import StarBackground from '../Landing/Assets/Stars.png';
 import './Landing.css';
 import SimpleFooter from '../../components/FooterPane/SimpleFooter';
+import AuthComponent from './Login_Signup/AuthComponent';
 
 const PanelThree = () => {
     const [description, setDescription] = useState(<CardsDesc />);
@@ -65,15 +66,7 @@ const PanelThree = () => {
             <div className='main-text-section'
             > 
                 {description}
-                <div className='simple-footer-buttons'>
-                    <button className='button'>
-                        Login
-                    </button>
-                    <button className='button'>
-                        Sign Up
-                    </button>
-                </div>
-
+               <AuthComponent />
             </div>
             <SimpleFooter />
         </div>

--- a/client/src/pages/Landing/PanelTwo.jsx
+++ b/client/src/pages/Landing/PanelTwo.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import ImageGrid from './ImageGrid';
 import StarsBackground from '../Landing/Assets/Stars.png';
+import AuthComponent from './Login_Signup/AuthComponent';
 
 const PanelTwo = () => {
     const [hoveredItem, setHoveredItem] = useState('');
@@ -56,15 +57,7 @@ const PanelTwo = () => {
                     Discover diverse readings and tailored insights through various spreads!</h2>
             )}
 
-                <div style={{ zIndex: 5 }}>
-                    <button className='button'>
-                        Login
-                    </button>
-                    <button className='button'>
-                        Sign Up
-                    </button>
-                </div>
-           
+               <AuthComponent />
         </div >
     );
 };


### PR DESCRIPTION
Description: 
The original intention for this request was to consolidate CSS but I realized that the modals were not rendering on all panels of the landing page. I implemented the following changes. 

Additions: 
-Added an AuthButtons component to utilize among the 3 panels of the landing page to reduce redundant code
-Added an AuthComponent to house all of the login and signup functionality and include the modals for use in all 3 panels of the landing page
-Added AuthComponent import to all 3 panels on the landing page

Modifications: 
-Minor CSS changes to SimpleFooter.jsx, Landing.css
-Moved auth logic into its own component and removed it from PanelOne.jsx

Future Changes: 
-Still need to continue CSS consolidation and removing inline css properties