### PR TITLE
Fix login bug by standardizing field name to `_id` in GraphQL User schema

### DIFF
--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -8,7 +8,7 @@ const typeDefs = `
     }
 
     type User {
-        id: ID!
+        _id: ID!
         username: String!
         email: String!
         password: String!


### PR DESCRIPTION
### Description:
This PR fixes a bug on the login page caused by a mismatch between the field names used in the frontend and the GraphQL schema. The `User` schema has been updated to use `_id` instead of `id` for the user identifier field. This change ensures consistency across our application and resolves the 400 error encountered during login.

### PR Checklist:
- [x] Ensure your code follows the project's coding standards.
- [ ] Add Jira tasks in the project backlog to update documentation if necessary.

### Behavior:
**User Side:**
- [ ] Users should now be able to log in successfully without encountering the 400 error.

**Dev Side:**
- [ ] The user ID will be referred to as `_id` in the GraphQL queries and mutations.
- [ ] Verify that the login mutation and other relevant functionalities are working as expected with the updated field name.

### Jira Tasks:
Link to the related Jira tasks:
- [TDS-183: Login/Signup issues on landing page](https://tarotdeck.atlassian.net/browse/TDS-183)

### Optional Sections:

#### Background Context:
This change was made to fix a bug on the login page caused by a mismatch between the frontend and backend field names. Standardizing the field names to `_id` aligns them with MongoDB's default `_id` field and resolves the login issue.

#### Deployment Notes:
No special instructions for deploying the changes. Ensure the server is restarted to apply the updated schema.
