### PR TITLE
Refactor(css-settings): Fixed styling on Settings drop down menus[TDS 185]

### DIFF
--- a/client/src/pages/Settings/SelectorMenu.jsx
+++ b/client/src/pages/Settings/SelectorMenu.jsx
@@ -24,7 +24,16 @@ const SelectorComponent = ({ label, options, value, onChange }) => {
                         backgroundColor: '#4F3052',
                         borderRadius: '0',
                         border: 'none',
-                        color: 'whitesmoke'
+                        color: 'whitesmoke',
+                        '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+                            borderColor: 'rgb(168, 148, 103)'
+                        },
+                        '&:hover .MuiOutlinedInput-notchedOutline': {
+                            borderColor: 'rgb(168, 148, 103)'
+                        },
+                        '.MuiOutlinedInput-notchedOutline': {
+                            borderColor: 'rgb(168, 148, 103)'
+                        }
                     }}
                     labelId={`${label}-label`}
                     id={label}

--- a/client/src/pages/Settings/SelectorMenu.jsx
+++ b/client/src/pages/Settings/SelectorMenu.jsx
@@ -26,13 +26,16 @@ const SelectorComponent = ({ label, options, value, onChange }) => {
                         border: 'none',
                         color: 'whitesmoke',
                         '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-                            borderColor: 'rgb(168, 148, 103)'
+                            borderColor: 'rgb(168, 148, 103)',
+                            borderWidth: '1px'
                         },
                         '&:hover .MuiOutlinedInput-notchedOutline': {
-                            borderColor: 'rgb(168, 148, 103)'
+                            borderColor: 'rgb(168, 148, 103)',
+                            borderWidth: '1px'
                         },
                         '.MuiOutlinedInput-notchedOutline': {
-                            borderColor: 'rgb(168, 148, 103)'
+                            borderColor: 'rgb(168, 148, 103)',
+                            borderWidth: '1px'
                         }
                     }}
                     labelId={`${label}-label`}

--- a/client/src/pages/Settings/Settings.css
+++ b/client/src/pages/Settings/Settings.css
@@ -40,6 +40,7 @@
     margin-top: 50px;
 }
 /* settings Right CSS ************************************ */
+
 /* .notes,
 .list {
     display: flex;

--- a/client/src/pages/Settings/SettingsRight/Appearance.jsx
+++ b/client/src/pages/Settings/SettingsRight/Appearance.jsx
@@ -128,7 +128,6 @@ const Appearance = () => {
                     Theme:
                 </div>
                 <SelectorComponent
-                    label='Theme'
                     options={themeOptions}
                     value={preferences.theme}
                     onChange={(event) => handleSelectorChange('theme', event.target.value)}
@@ -147,7 +146,6 @@ const Appearance = () => {
                     Default Deck:
                 </div>
                 <SelectorComponent
-                    label='Default Deck'
                     options={deckOptions}
                     value={preferences.deck}
                     onChange={(event) => handleSelectorChange('deck', event.target.value)}
@@ -166,7 +164,6 @@ const Appearance = () => {
                     Default Spread:
                 </div>
                 <SelectorComponent
-                    label='Default Spread'
                     options={spreadOptions}
                     value={preferences.spread}
                     onChange={(event) => handleSelectorChange('spread', event.target.value)}

--- a/client/src/pages/Settings/SettingsRight/SettingsRight.jsx
+++ b/client/src/pages/Settings/SettingsRight/SettingsRight.jsx
@@ -6,16 +6,20 @@ import '../Settings.css';
 const SettingsRight = () => {
     return (
         <section
+            className='right-set-container'
             style={{
                 width: '50%',
+                height: '95%',
                 display: 'flex',
-                justifyContent: 'center',
+                justifyContent: 'stretch',
                 alignItems: 'center',
                 flexDirection: 'column',
-                borderLeft: '1px solid lightgrey'
+                borderLeft: '1px solid rgb(168, 148, 103)'
             }}>
             <Appearance />
+
             <Notifications />
+
             <AdvancedSecurity />
         </section>
     );


### PR DESCRIPTION
**Description:**
This PR removes the text at the top of the drop down menu items in the Appearance section and changes the blue border to gold to match the other text input boxes on the settings page.

** PR Checklist:**
  [x] Code follows the project's coding standards.
  [ ] Jira tasks added in the project backlog to update documentation if necessary.

**Behavior:**
- **User Side Behavior:**
  [ ] Users should see three drop down menu boxes under Appearance, each with a gold border.
  [ ] The user should not see a text title in the top left edge of the drop down menu, only an item in the center noting the contents of what is included in the drop down menu.
  [ ] Upon clicking on one of the drop down menus, the selected menu's border should appear bolder.
  [ ] When item has been selected from the menu, the border will go back to the original uniform thickness.
  [ ] The border to the left of the right half of the page is gold, no longer white, and the right side contents better fill the space with less room at the top. 

- **Developer Side Behavior:**
  [ ] Labels were removed from the Selector Components, and the color borders were changed to match other text input boxes for continuity. 
  [ ] UI is cleaner, a closer match to our vision, and ready for implementing CSS Themes and converting Settings page inline CSS. 

**Jira Tasks:**
- TDS-185 [https://tarotdeck.atlassian.net/jira/software/projects/TDS/boards/3/backlog?selectedIssue=TDS-185]

 
