### PR TITLE
Fix Spread Model Field Inconsistency: imgUrl to imageUrl in GraphQL Schema

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -5,6 +5,9 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
     plugins: [react()],
     server: {
+        watch: {
+            usePolling: true
+          },
         port: 3000,
         open: true,
         proxy: {

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -99,7 +99,7 @@ const typeDefs = `
         positions:[SpreadPositions]
         spreadTips: [String]
         tags: [String]
-        imgUrl: String
+        imageUrl: String
         objectCode: String
     }
 


### PR DESCRIPTION
**Description:**  
This PR addresses an inconsistency between the database field name and the field used in the application for the `Spread` model. The database uses `imageUrl`, while the application was using `imgUrl`. This mismatch caused errors when querying or updating `Spread` objects. The fix updates the GraphQL schema in `typedefs.js` to ensure that `imageUrl` is used consistently across both the application and database.

**PR Checklist:**
- [x] Code follows the project's coding standards.
- [ ] Jira tasks added to update documentation if necessary.
- [x] The code formatter was run before submitting PR, and if needed, changes were
made before submitting the PR request.

**Behavior:**
- **User side behavior:**  
 - [x ] N/A
- **Dev side behavior:**  
  - [ ] Check the GraphQL schema updates in `typedefs.js`.
  - [ ] Verify that any queries using `imgUrl` are updated to use `imageUrl`.
  - [ ] Run tests for all `Spread` related queries to ensure no breaking changes were introduced.

**Jira Tasks:**  
- [TDS-240](https://tarotdeck.atlassian.net/browse/TDS-240): Image urls not populating when querying objects with images.

**Background Context:**  
The inconsistency between the application and database field names (`imgUrl` vs `imageUrl`) was causing issues when interacting with the `Spread` model. This fix resolves the discrepancy by aligning the application with the database.

**Screenshots/GIFs:**  
![image](https://github.com/user-attachments/assets/b6087c13-4d7e-4665-8fd1-004cdf578d63)

**Additional Note:**

I have added a setting to the vite.config file to set use polling to true. This is the only way currently that my environment HMRs will work. It should not impact you but if it does, remove it and I will find another way.
