### PR TITLE
Frontend Menu System: Sliding Panels Buttons for Spreads and Decks

### DIFF
--- a/client/src/components/AsidePane/ReadingDrawer.css
+++ b/client/src/components/AsidePane/ReadingDrawer.css
@@ -40,22 +40,24 @@
 .decks-container {
     width: 50%;
     height: calc(100% - 4.5em);
-    overflow-y: auto;
     box-sizing: border-box;
 }
 
-/* Spreads container with left-side scrollbar */
-.spreads-container {
+/* Container for the spreads */
+.scrolling-spreads-container,
+.scrolling-decks-container {
+    overflow-y: auto;
+    height: 100%;
     direction: rtl;
 }
 
-/* Ensures content inside spreads container remains left-to-right */
-.spreads-container * {
+/* RTL direction for the spreads container */
+.scrolling-spreads-container * {
     direction: ltr;
 }
 
 /* Decks container with default right-side scrollbar */
-.decks-container {
+.scrolling-decks-container {
     direction: ltr;
 }
 

--- a/client/src/components/AsidePane/ReadingDrawer.css
+++ b/client/src/components/AsidePane/ReadingDrawer.css
@@ -12,38 +12,11 @@
     background-color: #382337;
     padding: 0.5em;
     display: flex;
-    justify-content: space-between;
+    justify-content: center;
     align-items: center;
     gap: 0.5em;
 }
 
-/* Styling for the selected button */
-.reading-button.selected {
-    background-color: transparent;
-    color: #a89467;
-    font-size: 1.5em;
-    border: none;
-    font-weight: bold;
-    text-align: center;
-    flex-grow: 1;
-}
-
-/* Styling for the unselected button */
-.reading-button.unselected {
-    background-color: #a89467;
-    color: #382337;
-    font-size: 1.2em;
-    padding: 0.3em;
-    border-radius: 8px;
-    font-weight: normal;
-    text-align: center;
-    flex-shrink: 0;
-}
-
-.reading-button.unselected:hover {
-    background-color: #fafaf7;
-    cursor: pointer;
-}
 /* Container for the sliding effect */
 .slide-container {
     display: flex;
@@ -134,6 +107,7 @@
 }
 
 /* Common styling for info buttons */
+.reading-button,
 .spread-info-btn,
 .deck-info-btn {
     border-radius: 6px;
@@ -150,6 +124,7 @@
 }
 
 /* Hover effect for info buttons */
+.reading-button:hover,
 .spread-info-btn:hover,
 .deck-info-btn:hover {
     background-color: #fafaf7;

--- a/client/src/components/AsidePane/ReadingDrawer.jsx
+++ b/client/src/components/AsidePane/ReadingDrawer.jsx
@@ -57,8 +57,8 @@ const ReadingAside = () => {
                     <div className='button-background'>
                         <button
                             onClick={handleDecksClick}
-                            className={`reading-button ${!isSpreadsVisible ? 'selected' : 'unselected'}`}>
-                            Decks
+                            className='reading-button'>
+                            View Decks
                         </button>
                     </div>
                     {spreadsItems.map((item, idx) => (
@@ -80,8 +80,8 @@ const ReadingAside = () => {
                     <div className='button-background'>
                         <button
                             onClick={handleSpreadsClick}
-                            className={`reading-button ${isSpreadsVisible ? 'selected' : 'unselected'}`}>
-                            Spreads
+                            className='reading-button'>
+                            View Spreads
                         </button>
                     </div>
                     {decksItems.map((item, idx) => (

--- a/client/src/components/AsidePane/ReadingDrawer.jsx
+++ b/client/src/components/AsidePane/ReadingDrawer.jsx
@@ -50,23 +50,17 @@ const ReadingAside = () => {
 
     return (
         <div className='reading-aside'>
-            <div className='button-background'>
-                <button
-                    onClick={handleSpreadsClick}
-                    className={`reading-button ${isSpreadsVisible ? 'selected' : 'unselected'}`}>
-                    Spreads
-                </button>
-                <button
-                    onClick={handleDecksClick}
-                    className={`reading-button ${!isSpreadsVisible ? 'selected' : 'unselected'}`}>
-                    Decks
-                </button>
-            </div>
-
             {/* Sliding container for spreads and decks */}
             <div className={`slide-container ${isSpreadsVisible ? 'show-spreads' : 'show-decks'}`}>
                 {/* Spreads Panel */}
                 <div className='spreads-container'>
+                    <div className='button-background'>
+                        <button
+                            onClick={handleDecksClick}
+                            className={`reading-button ${!isSpreadsVisible ? 'selected' : 'unselected'}`}>
+                            Decks
+                        </button>
+                    </div>
                     {spreadsItems.map((item, idx) => (
                         <div
                             key={idx}
@@ -83,6 +77,13 @@ const ReadingAside = () => {
 
                 {/* Decks Panel */}
                 <div className='decks-container'>
+                    <div className='button-background'>
+                        <button
+                            onClick={handleSpreadsClick}
+                            className={`reading-button ${isSpreadsVisible ? 'selected' : 'unselected'}`}>
+                            Spreads
+                        </button>
+                    </div>
                     {decksItems.map((item, idx) => (
                         <div
                             key={idx}

--- a/client/src/components/AsidePane/ReadingDrawer.jsx
+++ b/client/src/components/AsidePane/ReadingDrawer.jsx
@@ -61,18 +61,20 @@ const ReadingAside = () => {
                             View Decks
                         </button>
                     </div>
-                    {spreadsItems.map((item, idx) => (
-                        <div
-                            key={idx}
-                            className='spread-slide'>
-                            <img
-                                src={item.image}
-                                alt={item.name}
-                            />
-                            <p>{item.name}</p>
-                            <button className='spread-info-btn'>Spread Info</button>
-                        </div>
-                    ))}
+                    <div className='scrolling-spreads-container'>
+                        {spreadsItems.map((item, idx) => (
+                            <div
+                                key={idx}
+                                className='spread-slide'>
+                                <img
+                                    src={item.image}
+                                    alt={item.name}
+                                />
+                                <p>{item.name}</p>
+                                <button className='spread-info-btn'>Spread Info</button>
+                            </div>
+                        ))}
+                    </div>
                 </div>
 
                 {/* Decks Panel */}
@@ -84,22 +86,24 @@ const ReadingAside = () => {
                             View Spreads
                         </button>
                     </div>
-                    {decksItems.map((item, idx) => (
-                        <div
-                            key={idx}
-                            className='deck-slide'>
-                            <img
-                                src={item.image}
-                                alt={item.name}
-                            />
-                            <p>{item.name}</p>
-                            <button
-                                className='deck-info-btn'
-                                onClick={handleDeckButtonClick}>
-                                Deck Info
-                            </button>
-                        </div>
-                    ))}
+                    <div className='scrolling-decks-container'>
+                        {decksItems.map((item, idx) => (
+                            <div
+                                key={idx}
+                                className='deck-slide'>
+                                <img
+                                    src={item.image}
+                                    alt={item.name}
+                                />
+                                <p>{item.name}</p>
+                                <button
+                                    className='deck-info-btn'
+                                    onClick={handleDeckButtonClick}>
+                                    Deck Info
+                                </button>
+                            </div>
+                        ))}
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
### Description:  
This PR introduces the new sliding menu system for selecting between Spreads and Decks. The system allows users to navigate between two panels with independent scrolling while preserving a clean and intuitive UI. This marks a significant visual progress in the project, and it was a great opportunity to refine both the design and functionality.

Key changes include:
- Buttons for Spreads and Decks seapareted in top of panel to hide active panel button.
- Adjustments to button sizing and styles to improve UX.
- Added CSS class scoping to ensure styles don't impact other site elements.

### PR Checklist:
- [x] Ensure your code follows the project's coding standards.
- [ ] Add Jira tasks in the project backlog to update documentation if necessary.
- [x] The code formatter was run before submitting PR, and if needed, changes were
made before submitting the PR request.

### Behavior:
**User-side behavior:**
- [ ] Users can switch between Spreads and Decks with a smooth sliding animation.
- [ ] Scrollbars function independently for both Spreads and Decks.
- [ ] The correct(opposite) panel's button is visible and clicking does not impact other site elements.

**Dev-side behavior:**
- [ ] Code uses scoped CSS classes to prevent cross-component styling issues.
- [ ] Components are styled using project-approved formats.

### Jira Tasks:  
 -  [TDS-247](https://tarotdeck.atlassian.net/browse/TDS-247)

### Optional Sections:

#### Background Context:  
This sliding menu button edit was created to clear confusion about the active panel and how to access the hidden panel. Now users only see one button at a time and it indicates that they can click the button to view the other options list.

#### Screenshots/GIFs:  

https://github.com/user-attachments/assets/9de77aa3-958b-4e3c-aa0e-3a8a3ce6c8c1


#### Additional Notes:  
This is part of the first pass on the sliding menu system. Further style adjustments may be needed once the rest of the UI is finalized.

