### PR TITLE
Display Reading Cards on Board in Correct Positions

### DIFF
--- a/client/src/components/SpreadLayouts/OneCardCenter.jsx
+++ b/client/src/components/SpreadLayouts/OneCardCenter.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-const OneCardCenter = ({ spreadData, deckData }) => {
+const OneCardCenter = ({ spreadData, deckData, cardData, showCardFronts }) => {
     if (!spreadData || !deckData) {
         return <div>Loading...</div>;
     }
@@ -19,16 +19,47 @@ const OneCardCenter = ({ spreadData, deckData }) => {
                     height: '60vh',
                     textAlign: 'center'
                 }}>
-                {positions.map((pos, index) => (
-                    <div key={index}>
-                        <img
-                            src={deckBackImage}
-                            alt={`Card ${pos.positionNumber}`}
-                            style={{ width: '200px', height: 'auto' }}
-                        />
-                        <p>{pos.positionDetails}</p>
-                    </div>
-                ))}
+                {positions.map((pos, index) => {
+                    const card = cardData[index];
+                    const cardImageUrl = card?.card?.imageUrl;
+                    const cardOrientation = card?.orientation;
+
+                    return (
+                        <div
+                            key={index}
+                            style={{
+                                display: 'flex',
+                                flexDirection: 'column',
+                                alignItems: 'center',
+                                justifyContent: 'center'
+                            }}>
+                            {showCardFronts && card ? (
+                                <div>
+                                    <p>{card.card.cardName}</p>
+                                    <img
+                                        src={cardImageUrl}
+                                        alt={card.card.cardName}
+                                        style={{
+                                            width: '200px',
+                                            height: 'auto',
+                                            transform: cardOrientation === 'Reversed' ? 'rotate(180deg)' : 'none'
+                                        }}
+                                    />
+                                    <p>{pos.positionDetails}</p>
+                                </div>
+                            ) : (
+                                <div>
+                                    <img
+                                        src={deckBackImage}
+                                        alt={`Card ${pos.positionNumber}`}
+                                        style={{ width: '200px', height: 'auto' }}
+                                    />
+                                    <p>{pos.positionDetails}</p>
+                                </div>
+                            )}
+                        </div>
+                    );
+                })}
             </div>
         </section>
     );
@@ -46,7 +77,9 @@ OneCardCenter.propTypes = {
     }).isRequired,
     deckData: PropTypes.shape({
         imageUrl: PropTypes.string.isRequired
-    }).isRequired
+    }).isRequired,
+    cardData: PropTypes.array.isRequired,
+    showCardFronts: PropTypes.bool.isRequired
 };
 
 export default OneCardCenter;

--- a/client/src/components/SpreadLayouts/OneCardCenter.jsx
+++ b/client/src/components/SpreadLayouts/OneCardCenter.jsx
@@ -1,13 +1,12 @@
 import PropTypes from 'prop-types';
 
 const OneCardCenter = ({ spreadData, deckData }) => {
-    // Safely destructure to avoid errors if spreadData or deckData is undefined
     if (!spreadData || !deckData) {
         return <div>Loading...</div>;
     }
 
     const { positions } = spreadData;
-    const { imageUrl: deckBackImage } = deckData; // Deck back image URL
+    const { imageUrl: deckBackImage } = deckData;
 
     return (
         <section>
@@ -15,17 +14,17 @@ const OneCardCenter = ({ spreadData, deckData }) => {
                 className='one-card-center-layout'
                 style={{
                     display: 'flex',
-                    justifyContent: 'center', // Center horizontally
-                    alignItems: 'center', // Center vertically
-                    height: '60vh', // Adjust the height as needed
-                    textAlign: 'center' // Align text in the center
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                    height: '60vh',
+                    textAlign: 'center'
                 }}>
                 {positions.map((pos, index) => (
                     <div key={index}>
                         <img
-                            src={deckBackImage} // Use the deck back image
+                            src={deckBackImage}
                             alt={`Card ${pos.positionNumber}`}
-                            style={{ width: '200px', height: 'auto' }} // Adjust size as necessary
+                            style={{ width: '200px', height: 'auto' }}
                         />
                         <p>{pos.positionDetails}</p>
                     </div>
@@ -46,7 +45,7 @@ OneCardCenter.propTypes = {
         ).isRequired
     }).isRequired,
     deckData: PropTypes.shape({
-        imageUrl: PropTypes.string.isRequired // Ensure deck back image is required
+        imageUrl: PropTypes.string.isRequired
     }).isRequired
 };
 

--- a/client/src/components/SpreadLayouts/SixSpokesUpright.jsx
+++ b/client/src/components/SpreadLayouts/SixSpokesUpright.jsx
@@ -14,7 +14,7 @@ const SixSpokesUpright = ({ spreadData, deckData }) => {
                 className='six-spokes-upright-layout'
                 style={{
                     display: 'grid',
-                    gridTemplateColumns: '1fr 1fr 1fr', // 3 columns for the layout
+                    gridTemplateColumns: '1fr 1fr 1fr',
                     gap: '20px',
                     justifyItems: 'center',
                     alignItems: 'center',

--- a/client/src/components/SpreadLayouts/SixSpokesUpright.jsx
+++ b/client/src/components/SpreadLayouts/SixSpokesUpright.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-const SixSpokesUpright = ({ spreadData, deckData }) => {
+const SixSpokesUpright = ({ spreadData, deckData, cardData, showCardFronts }) => {
     if (!spreadData || !deckData) {
         return <div>Loading...</div>;
     }
@@ -33,16 +33,40 @@ const SixSpokesUpright = ({ spreadData, deckData }) => {
                     }}>
                     {positions
                         .filter((pos) => [5, 4].includes(pos.positionNumber))
-                        .map((pos, index) => (
-                            <div key={index}>
-                                <img
-                                    src={deckBackImage}
-                                    alt={`Card ${pos.positionNumber}`}
-                                    style={{ width: '100px', height: 'auto' }}
-                                />
-                                <p>{pos.positionDetails}</p>
-                            </div>
-                        ))}
+                        .map((pos, index) => {
+                            const card = cardData[index]; // Get the card
+                            const cardImageUrl = card?.card?.imageUrl;
+                            const cardOrientation = card?.orientation;
+                            return (
+                                <div key={index}>
+                                    {showCardFronts && card ? (
+                                        <div>
+                                            <p>{card.card.cardName}</p>
+                                            <img
+                                                src={cardImageUrl}
+                                                alt={card.card.cardName}
+                                                style={{
+                                                    width: '100px',
+                                                    height: 'auto',
+                                                    transform:
+                                                        cardOrientation === 'Reversed' ? 'rotate(180deg)' : 'none'
+                                                }}
+                                            />
+                                            <p>{pos.positionDetails}</p>
+                                        </div>
+                                    ) : (
+                                        <div>
+                                            <img
+                                                src={deckBackImage}
+                                                alt={`Card ${pos.positionNumber}`}
+                                                style={{ width: '100px', height: 'auto' }}
+                                            />
+                                            <p>{pos.positionDetails}</p>
+                                        </div>
+                                    )}
+                                </div>
+                            );
+                        })}
                 </div>
 
                 {/* Column 2 (Cards 6 and 3) */}
@@ -56,17 +80,39 @@ const SixSpokesUpright = ({ spreadData, deckData }) => {
                     {positions
                         .filter((pos) => [6, 3].includes(pos.positionNumber))
                         .map((pos, index) => {
+                            const card = cardData[index]; // Get the card
+                            const cardImageUrl = card?.card?.imageUrl;
+                            const cardOrientation = card?.orientation;
                             const height = pos.positionNumber === 3 ? '35%' : '50%';
                             return (
                                 <div
                                     key={index}
                                     style={{ height }}>
-                                    <img
-                                        src={deckBackImage}
-                                        alt={`Card ${pos.positionNumber}`}
-                                        style={{ width: '100px', height: 'auto' }}
-                                    />
-                                    <p>{pos.positionDetails}</p>
+                                    {showCardFronts && card ? (
+                                        <div>
+                                            <p>{card.card.cardName}</p>
+                                            <img
+                                                src={cardImageUrl}
+                                                alt={card.card.cardName}
+                                                style={{
+                                                    width: '100px',
+                                                    height: 'auto',
+                                                    transform:
+                                                        cardOrientation === 'Reversed' ? 'rotate(180deg)' : 'none'
+                                                }}
+                                            />
+                                            <p>{pos.positionDetails}</p>
+                                        </div>
+                                    ) : (
+                                        <div>
+                                            <img
+                                                src={deckBackImage}
+                                                alt={`Card ${pos.positionNumber}`}
+                                                style={{ width: '100px', height: 'auto' }}
+                                            />
+                                            <p>{pos.positionDetails}</p>
+                                        </div>
+                                    )}
                                 </div>
                             );
                         })}
@@ -83,18 +129,42 @@ const SixSpokesUpright = ({ spreadData, deckData }) => {
                     }}>
                     {positions
                         .filter((pos) => [1, 2].includes(pos.positionNumber))
-                        .map((pos, index) => (
-                            <div
-                                key={index}
-                                style={{ height: '50%' }}>
-                                <img
-                                    src={deckBackImage}
-                                    alt={`Card ${pos.positionNumber}`}
-                                    style={{ width: '100px', height: 'auto' }}
-                                />
-                                <p>{pos.positionDetails}</p>
-                            </div>
-                        ))}
+                        .map((pos, index) => {
+                            const card = cardData[index]; // Get the card
+                            const cardImageUrl = card?.card?.imageUrl;
+                            const cardOrientation = card?.orientation;
+                            return (
+                                <div
+                                    key={index}
+                                    style={{ height: '50%' }}>
+                                    {showCardFronts && card ? (
+                                        <div>
+                                            <p>{card.card.cardName}</p>
+                                            <img
+                                                src={cardImageUrl}
+                                                alt={card.card.cardName}
+                                                style={{
+                                                    width: '100px',
+                                                    height: 'auto',
+                                                    transform:
+                                                        cardOrientation === 'Reversed' ? 'rotate(180deg)' : 'none'
+                                                }}
+                                            />
+                                            <p>{pos.positionDetails}</p>
+                                        </div>
+                                    ) : (
+                                        <div>
+                                            <img
+                                                src={deckBackImage}
+                                                alt={`Card ${pos.positionNumber}`}
+                                                style={{ width: '100px', height: 'auto' }}
+                                            />
+                                            <p>{pos.positionDetails}</p>
+                                        </div>
+                                    )}
+                                </div>
+                            );
+                        })}
                 </div>
             </div>
         </section>
@@ -112,7 +182,9 @@ SixSpokesUpright.propTypes = {
     }).isRequired,
     deckData: PropTypes.shape({
         imageUrl: PropTypes.string.isRequired
-    }).isRequired
+    }).isRequired,
+    cardData: PropTypes.array.isRequired,
+    showCardFronts: PropTypes.bool.isRequired
 };
 
 export default SixSpokesUpright;

--- a/client/src/components/SpreadLayouts/ThreeCardHorizontal.jsx
+++ b/client/src/components/SpreadLayouts/ThreeCardHorizontal.jsx
@@ -1,13 +1,12 @@
 import PropTypes from 'prop-types';
 
-const ThreeCardHorizontal = ({ spreadData, deckData }) => {
-    // Safely destructure to avoid errors if spreadData or deckData is undefined
+const ThreeCardHorizontal = ({ spreadData, deckData, cardData, showCardFronts }) => {
     if (!spreadData || !deckData) {
         return <div>Loading...</div>;
     }
 
     const { positions } = spreadData;
-    const { imageUrl: deckBackImage } = deckData; // Deck back image URL
+    const { imageUrl: deckBackImage } = deckData; // Back of the card image from the deck
 
     return (
         <section>
@@ -15,30 +14,52 @@ const ThreeCardHorizontal = ({ spreadData, deckData }) => {
                 className='three-card-horizontal-layout'
                 style={{
                     display: 'grid',
-                    gridTemplateColumns: 'repeat(3, 1fr)', // 3 equal columns for the cards
-                    gridTemplateRows: '1fr', // 1 row for vertical centering
+                    gridTemplateColumns: 'repeat(3, 1fr)',
                     gap: '10px',
                     justifyContent: 'center',
-                    alignItems: 'center', // Centers vertically
-                    height: '100%' // Full height of the container
+                    alignItems: 'center',
+                    height: '100%'
                 }}>
-                {positions.map((pos, index) => (
-                    <div
-                        key={index}
-                        style={{
-                            display: 'flex',
-                            flexDirection: 'column',
-                            alignItems: 'center',
-                            justifyContent: 'center'
-                        }}>
-                        <img
-                            src={deckBackImage} // Use the deck back image
-                            alt={`Card ${pos.positionNumber}`}
-                            style={{ width: '200px', height: 'auto' }} // Adjust width for better spacing
-                        />
-                        <p>{pos.positionDetails}</p>
-                    </div>
-                ))}
+                {positions.map((pos, index) => {
+                    const card = cardData[index]; // Get the card at the current index
+                    const cardImageUrl = card?.card?.imageUrl; // Get the card image URL
+                    const cardOrientation = card?.orientation; // Get the card orientation
+
+                    return (
+                        <div
+                            key={index}
+                            style={{
+                                display: 'flex',
+                                flexDirection: 'column',
+                                alignItems: 'center',
+                                justifyContent: 'center'
+                            }}>
+                            {showCardFronts && card ? (
+                                <div>
+                                    <p>{card.card.cardName}</p> {/* Show the card name */}
+                                    <img
+                                        src={cardImageUrl} // Show the card image
+                                        alt={card.card.cardName}
+                                        style={{
+                                            width: '200px',
+                                            height: 'auto',
+                                            transform: cardOrientation === 'Reversed' ? 'rotate(180deg)' : 'none' // Rotate if reversed
+                                        }}
+                                    />
+                                </div>
+                            ) : (
+                                <div>
+                                    <img
+                                        src={deckBackImage} // Show card back before "Start Reading"
+                                        alt={`Card ${pos.positionNumber}`}
+                                        style={{ width: '200px', height: 'auto' }}
+                                    />
+                                    <p>{pos.positionDetails}</p>
+                                </div>
+                            )}
+                        </div>
+                    );
+                })}
             </div>
         </section>
     );
@@ -48,16 +69,16 @@ ThreeCardHorizontal.propTypes = {
     spreadData: PropTypes.shape({
         positions: PropTypes.arrayOf(
             PropTypes.shape({
-                gridColumn: PropTypes.string.isRequired,
-                gridRow: PropTypes.string.isRequired,
                 positionNumber: PropTypes.number.isRequired,
                 positionDetails: PropTypes.string.isRequired
             })
         ).isRequired
     }).isRequired,
     deckData: PropTypes.shape({
-        imageUrl: PropTypes.string.isRequired // Ensure deck back image is required
-    }).isRequired
+        imageUrl: PropTypes.string.isRequired
+    }).isRequired,
+    cardData: PropTypes.array.isRequired, // Card data passed after reading is generated
+    showCardFronts: PropTypes.bool.isRequired // Controls when to show the card fronts
 };
 
 export default ThreeCardHorizontal;

--- a/client/src/components/SpreadLayouts/ThreeCardHorizontal.jsx
+++ b/client/src/components/SpreadLayouts/ThreeCardHorizontal.jsx
@@ -6,7 +6,7 @@ const ThreeCardHorizontal = ({ spreadData, deckData, cardData, showCardFronts })
     }
 
     const { positions } = spreadData;
-    const { imageUrl: deckBackImage } = deckData; // Back of the card image from the deck
+    const { imageUrl: deckBackImage } = deckData;
 
     return (
         <section>
@@ -21,9 +21,9 @@ const ThreeCardHorizontal = ({ spreadData, deckData, cardData, showCardFronts })
                     height: '100%'
                 }}>
                 {positions.map((pos, index) => {
-                    const card = cardData[index]; // Get the card at the current index
-                    const cardImageUrl = card?.card?.imageUrl; // Get the card image URL
-                    const cardOrientation = card?.orientation; // Get the card orientation
+                    const card = cardData[index];
+                    const cardImageUrl = card?.card?.imageUrl;
+                    const cardOrientation = card?.orientation;
 
                     return (
                         <div
@@ -36,21 +36,22 @@ const ThreeCardHorizontal = ({ spreadData, deckData, cardData, showCardFronts })
                             }}>
                             {showCardFronts && card ? (
                                 <div>
-                                    <p>{card.card.cardName}</p> {/* Show the card name */}
+                                    <p>{card.card.cardName}</p>
                                     <img
-                                        src={cardImageUrl} // Show the card image
+                                        src={cardImageUrl}
                                         alt={card.card.cardName}
                                         style={{
                                             width: '200px',
                                             height: 'auto',
-                                            transform: cardOrientation === 'Reversed' ? 'rotate(180deg)' : 'none' // Rotate if reversed
+                                            transform: cardOrientation === 'Reversed' ? 'rotate(180deg)' : 'none'
                                         }}
                                     />
+                                    <p>{pos.positionDetails}</p>
                                 </div>
                             ) : (
                                 <div>
                                     <img
-                                        src={deckBackImage} // Show card back before "Start Reading"
+                                        src={deckBackImage}
                                         alt={`Card ${pos.positionNumber}`}
                                         style={{ width: '200px', height: 'auto' }}
                                     />
@@ -77,8 +78,8 @@ ThreeCardHorizontal.propTypes = {
     deckData: PropTypes.shape({
         imageUrl: PropTypes.string.isRequired
     }).isRequired,
-    cardData: PropTypes.array.isRequired, // Card data passed after reading is generated
-    showCardFronts: PropTypes.bool.isRequired // Controls when to show the card fronts
+    cardData: PropTypes.array.isRequired,
+    showCardFronts: PropTypes.bool.isRequired
 };
 
 export default ThreeCardHorizontal;

--- a/client/src/pages/NewReading/NewReading.jsx
+++ b/client/src/pages/NewReading/NewReading.jsx
@@ -11,22 +11,18 @@ import { CREATE_TAROT_READING } from '../../utils/mutations.js';
 
 const NewReading = () => {
     const { selectedSpread, selectedDeck, userId } = useReadingContext();
-
-    // State to track when to show card fronts
     const [showCardFronts, setShowCardFronts] = useState(false);
-    const [cardData, setCardData] = useState([]); // State to store the card data after reading is generated
+    const [cardData, setCardData] = useState([]);
 
-    // Set up useLazyQuery for creating the temporary reading
     const [createTemporaryReading, { data, loading, error }] = useLazyQuery(CREATE_TEMPORARY_READING);
 
-    // Set up useMutation for saving the reading
     const [createTarotReading, { loading: savingReading, error: saveError }] = useMutation(CREATE_TAROT_READING);
 
     useEffect(() => {
         if (data) {
             console.log('Temporary reading created:', data);
-            setCardData(data.generateTemporaryReading.cards); // Store the card data
-            setShowCardFronts(true); // Set to true to show card fronts
+            setCardData(data.generateTemporaryReading.cards);
+            setShowCardFronts(true);
         }
         if (error) {
             console.error('Error creating temporary reading:', error);
@@ -39,7 +35,7 @@ const NewReading = () => {
     const handleSaveReading = () => {
         if (data && data.generateTemporaryReading && selectedSpread && selectedDeck && userId) {
             const cardObjects = data.generateTemporaryReading.cards.map((card) => ({
-                card: card.card._id, // Extract the card ID
+                card: card.card._id,
                 position: card.position,
                 orientation: card.orientation
             }));
@@ -52,7 +48,7 @@ const NewReading = () => {
                     userId,
                     deckId: selectedDeck._id,
                     spreadId: selectedSpread._id,
-                    cardObjects // Pass the cardObjects array directly
+                    cardObjects
                 }
             })
                 .then((response) => {
@@ -67,7 +63,7 @@ const NewReading = () => {
     };
 
     const handleStartReading = () => {
-        console.log('Start reading clicked'); // Log when start reading is clicked
+        console.log('Start reading clicked');
         if (selectedSpread && selectedDeck && userId) {
             createTemporaryReading({
                 variables: {
@@ -112,8 +108,8 @@ const NewReading = () => {
                         <LayoutComponent
                             spreadData={selectedSpread}
                             deckData={selectedDeck}
-                            cardData={cardData} // Pass generated card data
-                            showCardFronts={showCardFronts} // Control when to show card fronts
+                            cardData={cardData}
+                            showCardFronts={showCardFronts}
                         />
                     ) : (
                         <p>No matching layout found for this spread.</p>

--- a/client/src/utils/mutations.js
+++ b/client/src/utils/mutations.js
@@ -104,7 +104,6 @@ export const CREATE_TAROT_READING = gql`
                 card {
                     _id
                     cardName
-                    imageUrl
                 }
                 position
                 orientation

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -253,9 +253,7 @@ const resolvers = {
         me: async (_, __, context) => {
             checkAuthentication(context, context.user?._id);
 
-            const me = await User.findOne({ _id: context.user._id })
-                .populate('defaultSpread') 
-                .populate('defaultDeck'); 
+            const me = await User.findOne({ _id: context.user._id }).populate('defaultSpread').populate('defaultDeck');
 
             return handleNotFound(me, 'User', context.user._id);
         },
@@ -275,7 +273,6 @@ const resolvers = {
         // TODO: integrate s3 queries where needed
         generateTemporaryReading: async (_, { userId, deckId, spreadId }, context) => {
             try {
-
                 checkAuthentication(context, userId);
 
                 const spread = await Spread.findOne({ _id: spreadId });
@@ -292,7 +289,6 @@ const resolvers = {
 
                 const selectedCardIds = drawCards(deck.cards, spread.numCards).map((card) => card._id);
 
-  
                 const selectedCards = await Card.find({ _id: { $in: selectedCardIds } });
 
                 console.log('Selected Cards:', selectedCards);
@@ -300,13 +296,12 @@ const resolvers = {
                 const cardObjects = selectedCards.map((card, index) => ({
                     card: {
                         _id: card._id,
-                        cardName: card.cardName, 
+                        cardName: card.cardName,
                         imageUrl: card.imageUrl
                     },
                     position: index + 1,
                     orientation: Math.random() < 0.5 ? 'Upright' : 'Reversed'
                 }));
-
 
                 return {
                     deck: {
@@ -317,7 +312,7 @@ const resolvers = {
                         _id: spread._id,
                         spreadName: spread.spreadName
                     },
-                    cards: cardObjects 
+                    cards: cardObjects
                 };
             } catch (error) {
                 console.error('Error generating temporary reading:', error);
@@ -595,7 +590,6 @@ const resolvers = {
             // Update the user's readings array
             await User.findByIdAndUpdate(userId, { $addToSet: { readings: reading._id } }, { new: true });
 
-  
             await reading.populate([
                 { path: 'deck', select: 'deckName' },
                 { path: 'spread', select: 'spreadName' },

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -253,10 +253,9 @@ const resolvers = {
         me: async (_, __, context) => {
             checkAuthentication(context, context.user?._id);
 
-            // Populate the defaultSpread and defaultDeck fields
             const me = await User.findOne({ _id: context.user._id })
-                .populate('defaultSpread') // Populate the spread data
-                .populate('defaultDeck'); // Populate the deck data
+                .populate('defaultSpread') 
+                .populate('defaultDeck'); 
 
             return handleNotFound(me, 'User', context.user._id);
         },
@@ -276,10 +275,9 @@ const resolvers = {
         // TODO: integrate s3 queries where needed
         generateTemporaryReading: async (_, { userId, deckId, spreadId }, context) => {
             try {
-                // Check authentication
+
                 checkAuthentication(context, userId);
 
-                // Fetch the spread and deck, ensuring we only get card IDs in the deck
                 const spread = await Spread.findOne({ _id: spreadId });
                 const deck = await Deck.findOne({ _id: deckId });
 
@@ -292,26 +290,24 @@ const resolvers = {
                     throw new Error('Deck not found');
                 }
 
-                // Draw random cards by IDs from the deck
                 const selectedCardIds = drawCards(deck.cards, spread.numCards).map((card) => card._id);
 
-                // Now, fetch full card objects based on those selectedCardIds
+  
                 const selectedCards = await Card.find({ _id: { $in: selectedCardIds } });
 
                 console.log('Selected Cards:', selectedCards);
 
-                // Create card objects with full card details (including cardName and imageUrl)
                 const cardObjects = selectedCards.map((card, index) => ({
                     card: {
                         _id: card._id,
-                        cardName: card.cardName, // Fetch full card details here
+                        cardName: card.cardName, 
                         imageUrl: card.imageUrl
                     },
                     position: index + 1,
                     orientation: Math.random() < 0.5 ? 'Upright' : 'Reversed'
                 }));
 
-                // Return the deck, spread, and selected cards
+
                 return {
                     deck: {
                         _id: deck._id,
@@ -321,7 +317,7 @@ const resolvers = {
                         _id: spread._id,
                         spreadName: spread.spreadName
                     },
-                    cards: cardObjects // Includes card details
+                    cards: cardObjects 
                 };
             } catch (error) {
                 console.error('Error generating temporary reading:', error);
@@ -562,61 +558,51 @@ const resolvers = {
             return updateObjectArrays(userId, input, User.findOneAndUpdate.bind(User), 'readings');
         },
 
-        createTarotReading: async (_, { userId, deckId, spreadId }, context) => {
+        createTarotReading: async (_, { userId, deckId, spreadId, cardObjects }, context) => {
             checkAuthentication(context, userId);
 
             const spread = await Spread.findOne({ _id: spreadId });
-            const deck = await Deck.findOne({ _id: deckId }).populate('cards');
-            const selectedCards = drawCards(deck.cards, spread.numCards);
+            const deck = await Deck.findOne({ _id: deckId });
 
-            const cardObjects = selectedCards.map((card, index) => ({
-                card: card._id,
-                position: index + 1,
-                orientation: Math.random() < 0.5 ? 'Upright' : 'Reversed'
-            }));
+            if (!spread) {
+                throw new Error('Spread not found');
+            }
+            if (!deck) {
+                throw new Error('Deck not found');
+            }
+
+            const cardIds = cardObjects.map((cardObj) => cardObj.card);
+            const fullCards = await Card.find({ _id: { $in: cardIds } });
+
+            const savedCardObjects = cardObjects.map((cardObj) => {
+                const fullCard = fullCards.find((card) => card._id.toString() === cardObj.card);
+                return {
+                    card: fullCard._id,
+                    position: cardObj.position,
+                    orientation: cardObj.orientation
+                };
+            });
 
             const reading = new Reading({
-                user: context.user._id,
+                user: userId,
                 deck: deck._id,
                 spread: spread._id,
-                cards: cardObjects
+                cards: savedCardObjects
             });
 
             await reading.save();
 
-            // Use populate with an array of paths to populate multiple fields at once
+            // Update the user's readings array
+            await User.findByIdAndUpdate(userId, { $addToSet: { readings: reading._id } }, { new: true });
+
+  
             await reading.populate([
                 { path: 'deck', select: 'deckName' },
                 { path: 'spread', select: 'spreadName' },
-                { path: 'cards.card', select: 'cardName' }
+                { path: 'cards.card', select: 'cardName imageUrl' }
             ]);
 
-            console.log('READING ID: ', reading._id);
-
-            // Now update the user's readings array
-            const user = await User.findByIdAndUpdate(userId, { $addToSet: { readings: reading._id } }, { new: true });
-
-            if (!user) {
-                throw new Error('User not found');
-            }
-
             return reading;
-        },
-
-        updateReadingNotes: async (_, { userId, readingId, input }, context) => {
-            checkAuthentication(context, userId);
-            const reading = await Reading.findOne({ _id: readingId });
-
-            if (!reading) {
-                throw new Error('Reading not found');
-            }
-
-            reading.userNotes = input;
-            await reading.save();
-
-            return {
-                message: 'Notes added successfully to reading.'
-            };
         },
 
         deleteReading: async (_, { userId, readingId }, context) => {

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -274,6 +274,61 @@ const resolvers = {
 
         // dynamic data queries
         // TODO: integrate s3 queries where needed
+        generateTemporaryReading: async (_, { userId, deckId, spreadId }, context) => {
+            try {
+                // Check authentication
+                checkAuthentication(context, userId);
+
+                // Fetch the spread and deck, ensuring we only get card IDs in the deck
+                const spread = await Spread.findOne({ _id: spreadId });
+                const deck = await Deck.findOne({ _id: deckId });
+
+                console.log('Deck:', deck);
+
+                if (!spread) {
+                    throw new Error('Spread not found');
+                }
+                if (!deck) {
+                    throw new Error('Deck not found');
+                }
+
+                // Draw random cards by IDs from the deck
+                const selectedCardIds = drawCards(deck.cards, spread.numCards).map((card) => card._id);
+
+                // Now, fetch full card objects based on those selectedCardIds
+                const selectedCards = await Card.find({ _id: { $in: selectedCardIds } });
+
+                console.log('Selected Cards:', selectedCards);
+
+                // Create card objects with full card details (including cardName and imageUrl)
+                const cardObjects = selectedCards.map((card, index) => ({
+                    card: {
+                        _id: card._id,
+                        cardName: card.cardName, // Fetch full card details here
+                        imageUrl: card.imageUrl
+                    },
+                    position: index + 1,
+                    orientation: Math.random() < 0.5 ? 'Upright' : 'Reversed'
+                }));
+
+                // Return the deck, spread, and selected cards
+                return {
+                    deck: {
+                        _id: deck._id,
+                        deckName: deck.deckName
+                    },
+                    spread: {
+                        _id: spread._id,
+                        spreadName: spread.spreadName
+                    },
+                    cards: cardObjects // Includes card details
+                };
+            } catch (error) {
+                console.error('Error generating temporary reading:', error);
+                throw new Error('Failed to generate the temporary reading');
+            }
+        },
+
         allReadingsByUser: async (_, { userId }, context) => {
             checkAuthentication(context, userId);
 


### PR DESCRIPTION
### **Description:**
This PR implements the feature where reading cards are displayed on the board in their correct positions when a user starts a reading. The cards are correctly placed according to the selected spread and deck, but no interactive "flipping" functionality is included in this update.

The changes ensure that when a reading is initiated, the appropriate cards appear in the layout without any manual user input needed for card arrangement.

### **PR Checklist:**
- [x] Code follows the project’s coding standards.
- [x] Formatter was run before PR submitted

### **Behavior:**
**User Side:**
- [ ] User selects a deck and spread.
- [ ] Clicking "Start Reading" populates the board with cards in their correct positions based on the spread.

**Developer Side:**
- [ ] Verify that the cards populate the board in the correct order.
- [ ] Ensure the `generateTemporaryReading` function works correctly, displaying card images and names.

### **Jira Tasks:**
- [TDS-273](https://tarotdeck.atlassian.net/browse/TDS-273)

### **Background Context:**
This PR focuses on the display of cards in their correct positions for the selected spread and deck. Interactive card flipping will be implemented in future updates.
